### PR TITLE
Add changes for the enacted vote on 2021.12.09

### DIFF
--- a/scripts/vote_2021_12_09.py
+++ b/scripts/vote_2021_12_09.py
@@ -6,6 +6,8 @@ Voting 09/12/2021.
 3. Top up Sushi LP reward program with 50,000 LDO to 0xE5576eB1dD4aA524D67Cf9a32C8742540252b6F4
 4. Referral program payout of 140,414 LDO to financial multisig 0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb
 
+Vote passed & executed on 2021-12-10, 15:34, block 13777444.
+
 """
 
 import time

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,11 +70,12 @@ class Helpers:
             '0xa2dfc431297aee387c05beef507e5335e684fbcd'
         ]
 
-        for holder_addr in ldo_holders:
-            print('voting from acct:', holder_addr)
-            accounts[0].transfer(holder_addr, '0.1 ether')
-            account = accounts.at(holder_addr, force=True)
-            dao_voting.vote(vote_id, True, False, {'from': account})
+        if dao_voting.getVote(vote_id)[0]:
+            for holder_addr in ldo_holders:
+                print('voting from acct:', holder_addr)
+                accounts[0].transfer(holder_addr, '0.1 ether')
+                account = accounts.at(holder_addr, force=True)
+                dao_voting.vote(vote_id, True, False, {'from': account})
 
         # wait for the vote to end
         chain.sleep(3 * 60 * 60 * 24)

--- a/tests/event_validators/payout.py
+++ b/tests/event_validators/payout.py
@@ -11,13 +11,13 @@ class Payout(NamedTuple):
     amount: int
 
 def validate_payout_event (event: EventDict, p: Payout):
-    _ldo_events_chain = ['LogScriptCall', 'NewTransaction', 'Transfer', 'VaultTransfer']
+    _ldo_events_chain = ['LogScriptCall', 'NewPeriod', 'NewTransaction', 'Transfer', 'VaultTransfer']
 
     events_chain = [e.name for e in event]
-    for ev in _ldo_events_chain:
-        idx = next((events_chain.index(e) for e in events_chain if e == ev), len(events_chain))
-        assert idx != len(events_chain), f"{ev} not found in the remaining {events_chain} events chain"
-        events_chain=events_chain[idx:]
+    for ev in events_chain:
+        idx = next((_ldo_events_chain.index(e) for e in _ldo_events_chain if e == ev), len(_ldo_events_chain))
+        assert idx != len(_ldo_events_chain), f"{ev} not found in the remaining {_ldo_events_chain} events chain"
+        _ldo_events_chain=_ldo_events_chain[idx:]
 
     assert event.count('VaultTransfer') == 1
     assert event.count('Transfer') == 1

--- a/tests/event_validators/payout.py
+++ b/tests/event_validators/payout.py
@@ -10,16 +10,27 @@ class Payout(NamedTuple):
     to_addr: str
     amount: int
 
+# Check that all tx_events contained in reference_events (with proper ordering and occurrences count).
+# Allow some of the reference_events skipped in the tx_events. 
+#
+# Examples:
+#
+# tx_events: ['A', 'B', 'C'], reference_events: ['A', 'B', 'C'] => valid
+# tx_events: ['A', 'B', 'D'], reference_events: ['A', 'B', 'C', 'D'] => valid
+#
+# tx_events: ['A', 'B', 'D'], reference_events: ['A', 'B', 'C'] => invalid // extra 'D' event
+# tx_events: ['A', 'B', 'A', 'B'], reference_events: ['A', 'B'] => invalid // duplicated 'A', 'B' events chain
+# tx_events: ['A', 'C', 'B'], reference_events: ['A', 'B', 'C'] => invalid // wrong order
+def validate_events_chain (tx_events: [str], reference_events: [str]):
+    for ev in tx_events:
+        idx = next((reference_events.index(e) for e in reference_events if e == ev), len(reference_events))
+        assert idx != len(reference_events), f"{ev} not found in the remaining {reference_events} events chain"
+        reference_events=reference_events[idx+1:]
+
 def validate_payout_event (event: EventDict, p: Payout):
     _ldo_events_chain = ['LogScriptCall', 'NewPeriod', 'NewTransaction', 'Transfer', 'VaultTransfer']
 
-    # We check that transaction events contained in _ldo_events_chain (ordering and occurrences count are preserved)
-    # e.g. duplicated chain will trigger assert
-    events_chain = [e.name for e in event]
-    for ev in events_chain:
-        idx = next((_ldo_events_chain.index(e) for e in _ldo_events_chain if e == ev), len(_ldo_events_chain))
-        assert idx != len(_ldo_events_chain), f"{ev} not found in the remaining {_ldo_events_chain} events chain"
-        _ldo_events_chain=_ldo_events_chain[idx:]
+    validate_events_chain ([e.name for e in event], _ldo_events_chain)
 
     assert event.count('VaultTransfer') == 1
     assert event.count('Transfer') == 1

--- a/tests/event_validators/payout.py
+++ b/tests/event_validators/payout.py
@@ -13,7 +13,11 @@ class Payout(NamedTuple):
 def validate_payout_event (event: EventDict, p: Payout):
     _ldo_events_chain = ['LogScriptCall', 'NewTransaction', 'Transfer', 'VaultTransfer']
 
-    assert _ldo_events_chain == [e.name for e in event], "Invalid LDO payout events chain"
+    events_chain = [e.name for e in event]
+    for ev in _ldo_events_chain:
+        idx = next((events_chain.index(e) for e in events_chain if e == ev), len(events_chain))
+        assert idx != len(events_chain), f"{ev} not found in the remaining {events_chain} events chain"
+        events_chain=events_chain[idx:]
 
     assert event.count('VaultTransfer') == 1
     assert event.count('Transfer') == 1

--- a/tests/event_validators/payout.py
+++ b/tests/event_validators/payout.py
@@ -13,6 +13,8 @@ class Payout(NamedTuple):
 def validate_payout_event (event: EventDict, p: Payout):
     _ldo_events_chain = ['LogScriptCall', 'NewPeriod', 'NewTransaction', 'Transfer', 'VaultTransfer']
 
+    # We check that transaction events contained in _ldo_events_chain (ordering and occurrences count are preserved)
+    # e.g. duplicated chain will trigger assert
     events_chain = [e.name for e in event]
     for ev in events_chain:
         idx = next((_ldo_events_chain.index(e) for e in _ldo_events_chain if e == ev), len(_ldo_events_chain))


### PR DESCRIPTION
There are three changes included in the PR:
- vote execution timestamp and block id 
- bypass vote creation on already created vote to prevent crash
- tweak events chain test on payment transactions.