### PR TITLE
Omnibus refactorings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ To run tests you need to set the additional brownie commandline params: `--netwo
 export ETHERSCAN_TOKEN=<etherscan_key>
 export WEB3_INFURA_PROJECT_ID=<infura_key>
 ```
+
+###### Running tests inside mainnet fork
+
+* To re-use already created `vote_id` you can pass the `OMNIBUS_VOTE_ID` environment variable (e.g. `OMNIBUS_VOTE_ID=104`).
+* To forcely bypass etherscan contract and event names decoding set the `OMNIBUS_BYPASS_EVENTS_DECODING` environment variable to `1`.
 #### Mainnet
 
 To run scripts on actually mainnet you need to add param `--network mainnet` to the end of the command and set the following env variables:
@@ -22,7 +27,6 @@ To run scripts on actually mainnet you need to add param `--network mainnet` to 
 export DEPLOYER=<brownie_wallet_name>
 export WEB3_INFURA_PROJECT_ID=<infura_key>
 ```
-
 ## Adding node operators
 
 Script to pack up adding new node operators in one vote

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+import os
+
 from typing import Optional, List
 
 from brownie import chain
@@ -84,9 +86,31 @@ class Helpers:
         assert dao_voting.canExecute(vote_id)
         tx = dao_voting.executeVote(vote_id, {'from': accounts[0]})
 
-        print(f'vote executed')
+        print(f'vote #{vote_id} executed')
         return tx
 
 @pytest.fixture(scope='module')
 def helpers():
-    return Helpers()
+    return Helpers
+
+@pytest.fixture(scope='module')
+def vote_id_from_env() -> Optional[int]:
+    _env_name = "OMNIBUS_VOTE_ID"
+    if os.getenv(_env_name):
+        try:
+            vote_id = int(os.getenv(_env_name))
+            print(f'OMNIBUS_VOTE_ID env var is set, using existing vote #{vote_id}')
+            return vote_id
+        except:
+            pass
+
+    return None
+
+@pytest.fixture(scope='module')
+def bypass_events_decoding() -> bool:
+    _env_name = "OMNIBUS_BYPASS_EVENTS_DECODING"
+    if os.getenv(_env_name):
+        print(f'Warning: OMNIBUS_BYPASS_EVENTS_DECODING env var is set, events decoding disabled')
+        return True
+
+    return False

--- a/tests/test_2021_12_09.py
+++ b/tests/test_2021_12_09.py
@@ -45,7 +45,7 @@ referral_10th_payout = Payout(
     amount=140_414 * (10 ** 18)
 )
 
-def test_2021_12_09(helpers, accounts, ldo_holder, dao_voting, ldo_token):
+def test_2021_12_09(helpers, accounts, ldo_holder, dao_voting, ldo_token, vote_id_from_env, bypass_events_decoding):
     curve_LP_balance_before = ldo_token.balanceOf(curve_LP_reward_manager_address)
     balancer_LP_balance_before = ldo_token.balanceOf(balancer_LP_reward_manager_address)
     sushi_LP_balance_before = ldo_token.balanceOf(sushi_LP_reward_manager_address)
@@ -53,9 +53,12 @@ def test_2021_12_09(helpers, accounts, ldo_holder, dao_voting, ldo_token):
 
     dao_balance_before = ldo_token.balanceOf(dao_agent_address)
 
-    vote_id, _ = start_vote({
-        'from': ldo_holder
-    }, silent=True)
+    vote_id = vote_id_from_env
+
+    if vote_id is None:
+        vote_id, _ = start_vote({
+            'from': ldo_holder
+        }, silent=True)
 
     tx: TransactionReceipt = helpers.execute_vote(
         vote_id=vote_id, accounts=accounts, dao_voting=dao_voting
@@ -83,16 +86,17 @@ def test_2021_12_09(helpers, accounts, ldo_holder, dao_voting, ldo_token):
     display_voting_events(tx)
     # display_voting_call_trace(tx) # uncomment for a paranoid mode ON
 
-    evs = group_voting_events(tx)
+    if not bypass_events_decoding:
+        evs = group_voting_events(tx)
 
-    # asserts on vote item 1
-    validate_payout_event(evs[0], curve_LP_payout)
+        # asserts on vote item 1
+        validate_payout_event(evs[0], curve_LP_payout)
 
-    # asserts on vote item 2
-    validate_payout_event(evs[1], balancer_LP_payout)
+        # asserts on vote item 2
+        validate_payout_event(evs[1], balancer_LP_payout)
 
-    # asserts on vote item 3
-    validate_payout_event(evs[2], sushi_LP_payout)
+        # asserts on vote item 3
+        validate_payout_event(evs[2], sushi_LP_payout)
 
-    # asserts on vote item 4
-    validate_payout_event(evs[3], referral_10th_payout)
+        # asserts on vote item 4
+        validate_payout_event(evs[3], referral_10th_payout)

--- a/tests/test_2021_12_09.py
+++ b/tests/test_2021_12_09.py
@@ -53,12 +53,7 @@ def test_2021_12_09(helpers, accounts, ldo_holder, dao_voting, ldo_token, vote_i
 
     dao_balance_before = ldo_token.balanceOf(dao_agent_address)
 
-    vote_id = vote_id_from_env
-
-    if vote_id is None:
-        vote_id, _ = start_vote({
-            'from': ldo_holder
-        }, silent=True)
+    vote_id = vote_id_from_env or start_vote({'from': ldo_holder }, silent=True)[0]
 
     tx: TransactionReceipt = helpers.execute_vote(
         vote_id=vote_id, accounts=accounts, dao_voting=dao_voting
@@ -86,17 +81,15 @@ def test_2021_12_09(helpers, accounts, ldo_holder, dao_voting, ldo_token, vote_i
     display_voting_events(tx)
     # display_voting_call_trace(tx) # uncomment for a paranoid mode ON
 
-    if not bypass_events_decoding:
-        evs = group_voting_events(tx)
+    if bypass_events_decoding:
+        return
 
-        # asserts on vote item 1
-        validate_payout_event(evs[0], curve_LP_payout)
-
-        # asserts on vote item 2
-        validate_payout_event(evs[1], balancer_LP_payout)
-
-        # asserts on vote item 3
-        validate_payout_event(evs[2], sushi_LP_payout)
-
-        # asserts on vote item 4
-        validate_payout_event(evs[3], referral_10th_payout)
+    evs = group_voting_events(tx)
+    # asserts on vote item 1
+    validate_payout_event(evs[0], curve_LP_payout)
+    # asserts on vote item 2
+    validate_payout_event(evs[1], balancer_LP_payout)
+    # asserts on vote item 3
+    validate_payout_event(evs[2], sushi_LP_payout)
+    # asserts on vote item 4
+    validate_payout_event(evs[3], referral_10th_payout)

--- a/tests/tx_tracing_helpers.py
+++ b/tests/tx_tracing_helpers.py
@@ -42,5 +42,8 @@ def group_voting_events(tx: TransactionReceipt) -> List[EventDict]:
 
     grouped_events = group_tx_events(events, EventDict(events), groups)
     ret = [v for k,v in grouped_events if k == _vote_item_group]
-    assert ret, "Can't group voting events, please read 'README.md' and pass all of the required brownie flags (e.g. --network <net>)"
+
+    assert ret, ("Can't group voting events. Please check that `ETHERSCAN_TOKEN` env var is set "
+                 "and all of the required brownie flags (e.g. --network mainnet-fork -s) are present")
+
     return ret

--- a/tests/tx_tracing_helpers.py
+++ b/tests/tx_tracing_helpers.py
@@ -41,4 +41,6 @@ def group_voting_events(tx: TransactionReceipt) -> List[EventDict]:
     groups = [_vote_item_group, _service_item_group]
 
     grouped_events = group_tx_events(events, EventDict(events), groups)
-    return [v for k,v in grouped_events if k == _vote_item_group]
+    ret = [v for k,v in grouped_events if k == _vote_item_group]
+    assert ret, "Can't group voting events, please read 'README.md' and pass all of the required brownie flags (e.g. --network <net>)"
+    return ret

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,13 +1,15 @@
 import os
 import sys
-from brownie import network, accounts
 
-try:
-    if network.show_active() == "goerli":
-        raise ImportError
-    from utils.config_mainnet import *
-except ImportError:
+from brownie import network, accounts
+from brownie.utils import color
+
+if network.show_active() == "goerli":
+    print(f'Using {color("cyan")}config_goerli.py{color} addresses')
     from utils.config_goerli import *
+else:
+    print(f'Using {color("magenta")}config_mainnet.py{color} addresses')
+    from utils.config_mainnet import *
 
 
 def get_is_live():


### PR DESCRIPTION
- assert on events parsing env and flags explicitly
- pass vote_id from env to skip vote creation (`OMNIBUS_VOTE_ID`)
- print executed vote_id
- allow to bypass events decoding tests with env variable (`OMNIBUS_BYPASS_EVENTS_DECODING`)
- output highlighted chain name