### PR TITLE
Feat: add scripts and tests for the voting on 24/03/2022

### DIFF
--- a/interfaces/AddRewardProgram.json
+++ b/interfaces/AddRewardProgram.json
@@ -1,0 +1,92 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_trustedCaller",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_rewardProgramsRegistry",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_creator",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_evmScriptCallData",
+        "type": "bytes"
+      }
+    ],
+    "name": "createEVMScript",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "_evmScriptCallData",
+        "type": "bytes"
+      }
+    ],
+    "name": "decodeEVMScriptCallData",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardProgramsRegistry",
+    "outputs": [
+      {
+        "internalType": "contract RewardProgramsRegistry",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "trustedCaller",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/interfaces/EasyTrack.json
+++ b/interfaces/EasyTrack.json
@@ -1,0 +1,1104 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_governanceToken",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_admin",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_motionDuration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_motionsCountLimit",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_objectionsThreshold",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_evmScriptExecutor",
+        "type": "address"
+      }
+    ],
+    "name": "EVMScriptExecutorChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_evmScriptFactory",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "_permissions",
+        "type": "bytes"
+      }
+    ],
+    "name": "EVMScriptFactoryAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_evmScriptFactory",
+        "type": "address"
+      }
+    ],
+    "name": "EVMScriptFactoryRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_motionId",
+        "type": "uint256"
+      }
+    ],
+    "name": "MotionCanceled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_motionId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "_creator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_evmScriptFactory",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "_evmScriptCallData",
+        "type": "bytes"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes",
+        "name": "_evmScript",
+        "type": "bytes"
+      }
+    ],
+    "name": "MotionCreated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_motionDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "MotionDurationChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_motionId",
+        "type": "uint256"
+      }
+    ],
+    "name": "MotionEnacted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_motionId",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_objector",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_weight",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_newObjectionsAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_newObjectionsAmountPct",
+        "type": "uint256"
+      }
+    ],
+    "name": "MotionObjected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "_motionId",
+        "type": "uint256"
+      }
+    ],
+    "name": "MotionRejected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_newMotionsCountLimit",
+        "type": "uint256"
+      }
+    ],
+    "name": "MotionsCountLimitChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "_newThreshold",
+        "type": "uint256"
+      }
+    ],
+    "name": "ObjectionsThresholdChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "CANCEL_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_MOTIONS_LIMIT",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAX_OBJECTIONS_THRESHOLD",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MIN_MOTION_DURATION",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "PAUSE_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "UNPAUSE_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_evmScriptFactory",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_permissions",
+        "type": "bytes"
+      }
+    ],
+    "name": "addEVMScriptFactory",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_motionId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "_objector",
+        "type": "address"
+      }
+    ],
+    "name": "canObjectToMotion",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "cancelAllMotions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_motionId",
+        "type": "uint256"
+      }
+    ],
+    "name": "cancelMotion",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "_motionIds",
+        "type": "uint256[]"
+      }
+    ],
+    "name": "cancelMotions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_evmScriptFactory",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_evmScriptCallData",
+        "type": "bytes"
+      }
+    ],
+    "name": "createMotion",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "_newMotionId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_motionId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_evmScriptCallData",
+        "type": "bytes"
+      }
+    ],
+    "name": "enactMotion",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "evmScriptExecutor",
+    "outputs": [
+      {
+        "internalType": "contract IEVMScriptExecutor",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "evmScriptFactories",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "evmScriptFactoryPermissions",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getEVMScriptFactories",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_motionId",
+        "type": "uint256"
+      }
+    ],
+    "name": "getMotion",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "evmScriptFactory",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "creator",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "duration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "startDate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "snapshotBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "objectionsThreshold",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "objectionsAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "evmScriptHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct EasyTrack.Motion",
+        "name": "",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getMotions",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "id",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "evmScriptFactory",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "creator",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "duration",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "startDate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "snapshotBlock",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "objectionsThreshold",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "objectionsAmount",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "evmScriptHash",
+            "type": "bytes32"
+          }
+        ],
+        "internalType": "struct EasyTrack.Motion[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "governanceToken",
+    "outputs": [
+      {
+        "internalType": "contract IMiniMeToken",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_maybeEVMScriptFactory",
+        "type": "address"
+      }
+    ],
+    "name": "isEVMScriptFactory",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "motionDuration",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "motions",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "id",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "evmScriptFactory",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "duration",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "startDate",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "snapshotBlock",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "objectionsThreshold",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "objectionsAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "evmScriptHash",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "motionsCountLimit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_motionId",
+        "type": "uint256"
+      }
+    ],
+    "name": "objectToMotion",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "objections",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "objectionsThreshold",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_evmScriptFactory",
+        "type": "address"
+      }
+    ],
+    "name": "removeEVMScriptFactory",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_evmScriptExecutor",
+        "type": "address"
+      }
+    ],
+    "name": "setEVMScriptExecutor",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_motionDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMotionDuration",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_motionsCountLimit",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMotionsCountLimit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_objectionsThreshold",
+        "type": "uint256"
+      }
+    ],
+    "name": "setObjectionsThreshold",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/interfaces/MiniMeToken.json
+++ b/interfaces/MiniMeToken.json
@@ -1,0 +1,586 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_spender",
+        "type": "address"
+      },
+      {
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "creationBlock",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_newController",
+        "type": "address"
+      }
+    ],
+    "name": "changeController",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "name": "_blockNumber",
+        "type": "uint256"
+      }
+    ],
+    "name": "balanceOfAt",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_cloneTokenName",
+        "type": "string"
+      },
+      {
+        "name": "_cloneDecimalUnits",
+        "type": "uint8"
+      },
+      {
+        "name": "_cloneTokenSymbol",
+        "type": "string"
+      },
+      {
+        "name": "_snapshotBlock",
+        "type": "uint256"
+      },
+      {
+        "name": "_transfersEnabled",
+        "type": "bool"
+      }
+    ],
+    "name": "createCloneToken",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "parentToken",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "generateTokens",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_blockNumber",
+        "type": "uint256"
+      }
+    ],
+    "name": "totalSupplyAt",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "transfersEnabled",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "parentSnapShotBlock",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_spender",
+        "type": "address"
+      },
+      {
+        "name": "_amount",
+        "type": "uint256"
+      },
+      {
+        "name": "_extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "approveAndCall",
+    "outputs": [
+      {
+        "name": "success",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "destroyTokens",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "name": "_spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "remaining",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_token",
+        "type": "address"
+      }
+    ],
+    "name": "claimTokens",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "tokenFactory",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_transfersEnabled",
+        "type": "bool"
+      }
+    ],
+    "name": "enableTransfers",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "controller",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "_tokenFactory",
+        "type": "address"
+      },
+      {
+        "name": "_parentToken",
+        "type": "address"
+      },
+      {
+        "name": "_parentSnapShotBlock",
+        "type": "uint256"
+      },
+      {
+        "name": "_tokenName",
+        "type": "string"
+      },
+      {
+        "name": "_decimalUnits",
+        "type": "uint8"
+      },
+      {
+        "name": "_tokenSymbol",
+        "type": "string"
+      },
+      {
+        "name": "_transfersEnabled",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "fallback"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "_controller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ClaimedTokens",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "_cloneToken",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "_snapshotBlock",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewCloneToken",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "_spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  }
+]

--- a/interfaces/RemoveRewardProgram.json
+++ b/interfaces/RemoveRewardProgram.json
@@ -1,0 +1,87 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_trustedCaller",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_rewardProgramsRegistry",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_creator",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_evmScriptCallData",
+        "type": "bytes"
+      }
+    ],
+    "name": "createEVMScript",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "_evmScriptCallData",
+        "type": "bytes"
+      }
+    ],
+    "name": "decodeEVMScriptCallData",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "_rewardProgram",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardProgramsRegistry",
+    "outputs": [
+      {
+        "internalType": "contract RewardProgramsRegistry",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "trustedCaller",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/interfaces/RewardProgramsRegistry.json
+++ b/interfaces/RewardProgramsRegistry.json
@@ -1,0 +1,367 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_admin",
+        "type": "address"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_addRewardProgramRoleHolders",
+        "type": "address[]"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_removeRewardProgramRoleHolders",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_rewardProgram",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "_title",
+        "type": "string"
+      }
+    ],
+    "name": "RewardProgramAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "_rewardProgram",
+        "type": "address"
+      }
+    ],
+    "name": "RewardProgramRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "ADD_REWARD_PROGRAM_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "REMOVE_REWARD_PROGRAM_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_rewardProgram",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "_title",
+        "type": "string"
+      }
+    ],
+    "name": "addRewardProgram",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getRewardPrograms",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_maybeRewardProgram",
+        "type": "address"
+      }
+    ],
+    "name": "isRewardProgram",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_rewardProgram",
+        "type": "address"
+      }
+    ],
+    "name": "removeRewardProgram",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "rewardPrograms",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/interfaces/TopUpRewardPrograms.json
+++ b/interfaces/TopUpRewardPrograms.json
@@ -1,0 +1,128 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_trustedCaller",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_rewardProgramsRegistry",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_finance",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_rewardToken",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_creator",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_evmScriptCallData",
+        "type": "bytes"
+      }
+    ],
+    "name": "createEVMScript",
+    "outputs": [
+      {
+        "internalType": "bytes",
+        "name": "",
+        "type": "bytes"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "_evmScriptCallData",
+        "type": "bytes"
+      }
+    ],
+    "name": "decodeEVMScriptCallData",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "_rewardPrograms",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "_amounts",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "finance",
+    "outputs": [
+      {
+        "internalType": "contract IFinance",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardProgramsRegistry",
+    "outputs": [
+      {
+        "internalType": "contract RewardProgramsRegistry",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "rewardToken",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "trustedCaller",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/scripts/vote_2022_03_24.py
+++ b/scripts/vote_2022_03_24.py
@@ -1,0 +1,111 @@
+"""
+Voting 24/03/2022.
+
+1. Add AddRewardProgram 0x929547490Ceb6AeEdD7d72F1Ab8957c0210b6E51 factory to Easy Track
+2. Add RemoveRewardProgram 0xE9eb838fb3A288bF59E9275Ccd7e124fDff88a9C factory to Easy Track
+3. Add TopUpRewardPrograms 0x54058ee0E0c87Ad813C002262cD75B98A7F59218 factory to Easy Track
+4. Send 350,000 LDO to 0x3A043ce95876683768D3D3FB80057be2ee3f2814 for Hyperelliptic & RockX
+   team for Lido-on-Avalanache comps
+5. Pass ownership of the 1inch rewarder 0xf5436129Cf9d8fa2a1cb6e591347155276550635
+   to TokensRecoverer 0x...
+6. Recover LDO funds from the 1inch rewarder 0xf5436129cf9d8fa2a1cb6e591347155276550635
+   to DAO Agent
+
+"""
+
+import time
+
+from typing import (Dict, Tuple, Optional)
+
+from brownie import RewardsManagerTokensRecoverer
+from brownie.network.transaction import TransactionReceipt
+
+from utils.agent import agent_forward
+from utils.finance import make_ldo_payout
+from utils.voting import confirm_vote_script, create_vote
+from utils.evm_script import encode_call_script
+from utils.config import get_deployer_account, contracts, get_is_live
+from utils.easy_track import add_evmscript_factory, create_permissions
+
+from utils.brownie_prelude import *
+
+def start_vote(
+        tx_params: Dict[str, str],
+        silent: bool = False
+) -> Tuple[int, Optional[TransactionReceipt]]:
+    """Prepare and run voting."""
+
+    finance = contracts.finance
+    ldo_token = contracts.ldo_token
+
+    reward_programs_registry = interface.RewardProgramsRegistry('0xfCaD241D9D2A2766979A2de208E8210eDf7b7D4F')
+    rewards_manager = interface.RewardsManager('0xf5436129Cf9d8fa2a1cb6e591347155276550635')
+    tokens_recoverer = RewardsManagerTokensRecoverer.at('0x1bdfFe0EBef3FEAdF2723D3330727D73f538959C')
+
+    encoded_call_script = encode_call_script([
+        # 1. Add AddRewardProgram 0x929547490Ceb6AeEdD7d72F1Ab8957c0210b6E51 factory to Easy Track
+        add_evmscript_factory(
+            factory='0x929547490Ceb6AeEdD7d72F1Ab8957c0210b6E51',
+            permissions=create_permissions(reward_programs_registry, 'addRewardProgram')
+        ),
+        # 2. Add RemoveRewardProgram 0xE9eb838fb3A288bF59E9275Ccd7e124fDff88a9C factory to Easy Track
+        add_evmscript_factory(
+            factory='0xE9eb838fb3A288bF59E9275Ccd7e124fDff88a9C',
+            permissions=create_permissions(reward_programs_registry, 'removeRewardProgram')
+        ),
+        # 3. Add TopUpRewardPrograms 0x54058ee0E0c87Ad813C002262cD75B98A7F59218 factory to Easy Track
+        add_evmscript_factory(
+            factory='0x54058ee0E0c87Ad813C002262cD75B98A7F59218',
+            permissions=create_permissions(finance, 'newImmediatePayment')
+        ),
+        # 4. Send 350,000 LDO to 0x3A043ce95876683768D3D3FB80057be2ee3f2814 for Hyperelliptic & RockX team for Lido-on-Avalanache comps
+        make_ldo_payout(
+            target_address='0x3A043ce95876683768D3D3FB80057be2ee3f2814',
+            ldo_in_wei=350_000 * (10 ** 18),
+            reference="Hyperelliptic & RockX team for Lido-on-Avalanache comps"
+        ),
+        # 5. Pass ownership of the 1inch rewarder 0xf5436129Cf9d8fa2a1cb6e591347155276550635
+        # to the TokensRecoverer 0x...
+        agent_forward([
+             (
+                 rewards_manager.address,
+                 rewards_manager.transfer_ownership.encode_input(tokens_recoverer.address)
+             )
+        ]),
+        # 6. Recover LDO funds from 1inch reward contract 0xf5436129cf9d8fa2a1cb6e591347155276550635
+        # to DAO Agent
+        (
+            tokens_recoverer.address,
+            tokens_recoverer.recover.encode_input(
+                rewards_manager.address,
+                ldo_token.address,
+                50_000 * 10 ** 18
+            )
+        )
+    ])
+
+    return confirm_vote_script(encoded_call_script, silent) and create_vote(
+        vote_desc=(
+            'Omnibus vote: '
+            '1. Add AddRewardProgram 0x929547490Ceb6AeEdD7d72F1Ab8957c0210b6E51 factory to Easy Track;'
+            '2. Add RemoveRewardProgram 0xE9eb838fb3A288bF59E9275Ccd7e124fDff88a9C factory to Easy Track;'
+            '3. Add TopUpRewardPrograms 0x54058ee0E0c87Ad813C002262cD75B98A7F59218 factory to Easy Track;'
+            '4. Send 350,000 LDO to 0x3A043ce95876683768D3D3FB80057be2ee3f2814 for Hyperelliptic & RockX team;'
+            '5. Pass ownership of the 1inch rewarder 0xf5436129Cf9d8fa2a1cb6e591347155276550635 to TokensRecoverer;'
+            '6. Recover LDO funds from the 1inch rewarder 0xf5436129cf9d8fa2a1cb6e591347155276550635 to DAO Agent.'
+        ),
+        evm_script=encoded_call_script,
+        tx_params=tx_params
+    )
+
+def main():
+    tx_params = { 'from': get_deployer_account() }
+    if get_is_live():
+        tx_params['max_fee'] = '300 gwei'
+        tx_params['priority_fee'] = '2 gwei'
+
+    vote_id, _ = start_vote(tx_params=tx_params)
+
+    vote_id >= 0 and print(f'Vote created: {vote_id}.')
+
+    time.sleep(5)  # hack for waiting thread #2.

--- a/scripts/vote_2022_03_24.py
+++ b/scripts/vote_2022_03_24.py
@@ -7,7 +7,7 @@ Voting 24/03/2022.
 4. Send 350,000 LDO to 0x3A043ce95876683768D3D3FB80057be2ee3f2814 for Hyperelliptic & RockX
    team for Lido-on-Avalanache comps
 5. Pass ownership of the 1inch rewarder 0xf5436129Cf9d8fa2a1cb6e591347155276550635
-   to TokensRecoverer 0x...
+   to TokensRecoverer 0x1bdfFe0EBef3FEAdF2723D3330727D73f538959C.
 6. Recover LDO funds from the 1inch rewarder 0xf5436129cf9d8fa2a1cb6e591347155276550635
    to DAO Agent
 
@@ -65,7 +65,7 @@ def start_vote(
             reference="Hyperelliptic & RockX team for Lido-on-Avalanache comps"
         ),
         # 5. Pass ownership of the 1inch rewarder 0xf5436129Cf9d8fa2a1cb6e591347155276550635
-        # to the TokensRecoverer 0x...
+        # to the TokensRecoverer 0x1bdfFe0EBef3FEAdF2723D3330727D73f538959C
         agent_forward([
              (
                  rewards_manager.address,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from utils.config import (ldo_token_address, lido_dao_voting_address,
                           lido_dao_deposit_security_module_address,
                           lido_dao_steth_address, lido_dao_acl_address,
                           lido_dao_finance_address, ldo_holder_address_for_tests,
-                          ldo_vote_executors_for_tests)
+                          ldo_vote_executors_for_tests, lido_easytrack)
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -65,6 +65,11 @@ def acl(interface):
 @pytest.fixture(scope="module")
 def finance(interface):
     return interface.Finance(lido_dao_finance_address)
+
+
+@pytest.fixture(scope="module")
+def easy_track(interface):
+    return interface.EasyTrack(lido_easytrack)
 
 
 class Helpers:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from brownie.network.transaction import TransactionReceipt
 from brownie.network.event import EventDict, _EventItem
 
 from utils.config import (ldo_token_address, lido_dao_voting_address,
-                          lido_dao_token_manager_address,
+                          lido_dao_token_manager_address, lido_dao_agent_address,
                           lido_dao_node_operators_registry,
                           lido_dao_deposit_security_module_address,
                           lido_dao_steth_address, lido_dao_acl_address,
@@ -31,6 +31,9 @@ def ldo_holder(accounts):
 def dao_voting(interface):
     return interface.Voting(lido_dao_voting_address)
 
+@pytest.fixture(scope='module')
+def dao_agent(interface):
+    return interface.Agent(lido_dao_agent_address)
 
 @pytest.fixture(scope='module')
 def node_operators_registry(interface):

--- a/tests/event_validators/easy_track.py
+++ b/tests/event_validators/easy_track.py
@@ -1,0 +1,20 @@
+from typing import NamedTuple
+
+from brownie.network.event import EventDict
+from .common import validate_events_chain
+
+
+class EVMScriptFactoryAdded(NamedTuple):
+    factory_addr: str
+    permissions: str
+
+
+def validate_evmscript_factory_added_event(event: EventDict, p: EVMScriptFactoryAdded):
+    _events_chain = ['LogScriptCall', 'EVMScriptFactoryAdded']
+
+    validate_events_chain([e.name for e in event], _events_chain)
+
+    assert event.count('EVMScriptFactoryAdded') == 1
+
+    assert event['EVMScriptFactoryAdded']['_evmScriptFactory'] == p.factory_addr
+    assert event['EVMScriptFactoryAdded']['_permissions'] == p.permissions

--- a/tests/event_validators/rewards_manager.py
+++ b/tests/event_validators/rewards_manager.py
@@ -1,0 +1,18 @@
+from typing import NamedTuple
+
+from brownie.network.event import EventDict
+from .common import validate_events_chain
+
+class OwnershipTransferred(NamedTuple):
+    previous_owner_addr: str
+    new_owner_addr: str
+
+def validate_ownership_transferred_event(event: EventDict, ot: OwnershipTransferred):
+    _events_chain = ['LogScriptCall', 'LogScriptCall', 'OwnershipTransferred', 'ScriptResult']
+
+    validate_events_chain([e.name for e in event], _events_chain)
+
+    assert event.count('OwnershipTransferred') == 1
+
+    assert event['OwnershipTransferred']['previousOwner'] == ot.previous_owner_addr
+    assert event['OwnershipTransferred']['newOwner'] == ot.new_owner_addr

--- a/tests/event_validators/tokens_recoverer.py
+++ b/tests/event_validators/tokens_recoverer.py
@@ -1,0 +1,37 @@
+from typing import NamedTuple
+
+from brownie.network.event import EventDict
+from .common import validate_events_chain
+
+class Recover(NamedTuple):
+    sender_addr: str
+    manager_addr: str
+    token_addr: str
+    amount: int
+    recovered_amount: int
+
+def validate_recover_event(event: EventDict, r: Recover, dao_agent: str):
+    _events_chain = ['LogScriptCall', 'Transfer', 'ERC20TokenRecovered', 'OwnershipTransferred', 'Recover']
+
+    validate_events_chain([e.name for e in event], _events_chain)
+
+    assert event.count('Recover') == 1
+    assert event.count('ERC20TokenRecovered') == 1
+    assert event.count('OwnershipTransferred') == 1
+    assert event.count('Transfer') == 1
+
+    assert event['Transfer']['from'] == r.manager_addr
+    assert event['Transfer']['to'] == dao_agent
+    assert event['Transfer']['value'] == r.recovered_amount
+
+    assert event['ERC20TokenRecovered']['token'] == r.token_addr
+    assert event['ERC20TokenRecovered']['amount'] == r.recovered_amount
+    assert event['ERC20TokenRecovered']['recipient'] == dao_agent
+
+    assert event['OwnershipTransferred']['newOwner'] == dao_agent
+
+    assert event['Recover']['sender'] == r.sender_addr
+    assert event['Recover']['manager'] == r.manager_addr
+    assert event['Recover']['token'] == r.token_addr
+    assert event['Recover']['amount'] == r.amount
+    assert event['Recover']['recovered_amount'] == r.recovered_amount

--- a/tests/test_2022_03_24.py
+++ b/tests/test_2022_03_24.py
@@ -92,13 +92,13 @@ def test_2022_03_24(
 
     _check_factories_sanity(accounts[5], accounts[6], ldo_token, easy_track)
 
-    ### validate vote events
-    # assert count_vote_items_by_events(tx) == 6, "Incorrect voting items count"
-
     display_voting_events(tx)
 
     if bypass_events_decoding:
         return
+
+    ### validate vote events
+    assert count_vote_items_by_events(tx, dao_voting) == 6, "Incorrect voting items count"
 
     evs = group_voting_events(tx)
 

--- a/tests/test_2022_03_24.py
+++ b/tests/test_2022_03_24.py
@@ -1,0 +1,234 @@
+"""
+Tests for voting 24/03/2022.
+"""
+
+from brownie import Contract, interface
+from brownie.network import chain
+from eth_abi import encode_single
+
+from event_validators.payout import Payout, validate_payout_event
+from event_validators.easy_track import EVMScriptFactoryAdded, validate_evmscript_factory_added_event
+
+from scripts.vote_2022_03_24 import start_vote
+from tx_tracing_helpers import *
+
+dao_agent_address = '0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c'
+hyperelliptic_rockx_multisig = '0x3A043ce95876683768D3D3FB80057be2ee3f2814'
+lido_dao_token = '0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32'
+
+one_inch_reward_manager = "0xf5436129Cf9d8fa2a1cb6e591347155276550635"
+tokens_recoverer = '0x1bdfFe0EBef3FEAdF2723D3330727D73f538959C'
+
+factories_to_add_with_vote = [
+    EVMScriptFactoryAdded(
+        factory_addr='0x929547490Ceb6AeEdD7d72F1Ab8957c0210b6E51',
+        permissions=('0xfCaD241D9D2A2766979A2de208E8210eDf7b7D4F' + 'fa508cef')
+    ),
+    EVMScriptFactoryAdded(
+        factory_addr='0xE9eb838fb3A288bF59E9275Ccd7e124fDff88a9C',
+        permissions=('0xfCaD241D9D2A2766979A2de208E8210eDf7b7D4F' + '945233e2')
+    ),
+    EVMScriptFactoryAdded(
+        factory_addr='0x54058ee0E0c87Ad813C002262cD75B98A7F59218',
+        permissions=('0xB9E5CBB9CA5b0d659238807E84D0176930753d86' + 'f6364846')
+    )
+]
+
+hyperelliptic_rockx_comp = Payout(
+    token_addr=lido_dao_token,
+    from_addr=dao_agent_address,
+    to_addr=hyperelliptic_rockx_multisig,
+    amount=350_000 * (10 ** 18)
+)
+
+def test_2022_03_24(
+    helpers, accounts, ldo_holder, dao_voting, ldo_token,
+    vote_id_from_env, bypass_events_decoding, easy_track
+):
+    dao_balance_before = ldo_token.balanceOf(dao_agent_address)
+    hr_multisig_balance_before = ldo_token.balanceOf(hyperelliptic_rockx_multisig)
+    rewards_manager_balance_before = ldo_token.balanceOf(one_inch_reward_manager)
+
+    # if rewards manager has no tokens transfer it from ldo_holder
+    if rewards_manager_balance_before == 0:
+        ldo_token.transfer(one_inch_reward_manager, 1 * 10 ** 18, {"from": ldo_holder})
+    rewards_manager_balance_before = ldo_token.balanceOf(one_inch_reward_manager)
+    assert rewards_manager_balance_before > 0
+
+    factories_before = easy_track.getEVMScriptFactories()
+
+    for f in factories_to_add_with_vote:
+        assert f.factory_addr not in factories_before
+
+    ##
+    ## START VOTE
+    ##
+    vote_id = vote_id_from_env or start_vote({'from': ldo_holder}, silent=True)[0]
+
+    tx: TransactionReceipt = helpers.execute_vote(
+        vote_id=vote_id, accounts=accounts, dao_voting=dao_voting
+    )
+
+    factories_after = easy_track.getEVMScriptFactories()
+
+    rewards_manager_balance_after = ldo_token.balanceOf(one_inch_reward_manager)
+    hr_multisig_balance_after = ldo_token.balanceOf(hyperelliptic_rockx_multisig)
+    dao_balance_after = ldo_token.balanceOf(dao_agent_address)
+
+    assert hr_multisig_balance_after - hr_multisig_balance_before == hyperelliptic_rockx_comp.amount
+    assert rewards_manager_balance_after == 0
+
+    assert dao_balance_before - dao_balance_after == \
+        hyperelliptic_rockx_comp.amount + (rewards_manager_balance_after - rewards_manager_balance_before)
+
+    for f in factories_to_add_with_vote:
+        assert f.factory_addr in factories_after
+
+    _check_factories_sanity(accounts[5], accounts[6], ldo_token, easy_track)
+
+    ### validate vote events
+    # assert count_vote_items_by_events(tx) == 6, "Incorrect voting items count"
+
+    display_voting_events(tx)
+
+    if bypass_events_decoding:
+        return
+
+    evs = group_voting_events(tx)
+
+    # asserts on vote item 1
+    validate_evmscript_factory_added_event(evs[0], factories_to_add_with_vote[0])
+
+    # asserts on vote item 2
+    validate_evmscript_factory_added_event(evs[1], factories_to_add_with_vote[1])
+
+    # asserts on vote item 3
+    validate_evmscript_factory_added_event(evs[2], factories_to_add_with_vote[2])
+
+    # asserts on vote item 4
+    validate_payout_event(evs[3], hyperelliptic_rockx_comp)
+
+def test_2022_03_24_zero_ldo_to_recover(
+    helpers, accounts, ldo_holder, dao_voting, ldo_token,
+    vote_id_from_env, bypass_events_decoding, easy_track,
+    dao_agent
+):
+    assert dao_agent.address == dao_agent_address
+
+    rewards_manager_balance_before = ldo_token.balanceOf(one_inch_reward_manager)
+    rewards_manager = interface.RewardsManager(one_inch_reward_manager)
+    dao_balance_before = ldo_token.balanceOf(dao_agent_address)
+
+    # if rewards manager has no tokens transfer it from agent
+    if rewards_manager_balance_before > 0:
+        rewards_manager.recover_erc20(ldo_token, rewards_manager_balance_before, {"from": dao_agent})
+
+    assert ldo_token.balanceOf(one_inch_reward_manager) == 0
+
+    ##
+    ## START VOTE
+    ##
+    vote_id = vote_id_from_env or start_vote({'from': ldo_holder}, silent=True)[0]
+
+    tx: TransactionReceipt = helpers.execute_vote(
+        vote_id=vote_id, accounts=accounts, dao_voting=dao_voting
+    )
+
+    rewards_manager_balance_after = ldo_token.balanceOf(one_inch_reward_manager)
+    dao_balance_after = ldo_token.balanceOf(dao_agent_address)
+
+    assert dao_balance_before - dao_balance_after == hyperelliptic_rockx_comp.amount - rewards_manager_balance_before
+    assert rewards_manager_balance_after == 0
+
+
+def _encode_calldata(signature, values):
+    return "0x" + encode_single(signature, values).hex()
+
+def _check_factories_sanity(
+    reward_program_addr: str,
+    stranger: str,
+    ldo: Contract,
+    easy_track: Contract
+):
+    reward_program = reward_program_addr
+    reward_program_title = "Our Reward Program"
+
+    add_reward_program = interface.AddRewardProgram(factories_to_add_with_vote[0].factory_addr)
+    remove_reward_program = interface.RemoveRewardProgram(factories_to_add_with_vote[1].factory_addr)
+    top_up_reward_programs = interface.TopUpRewardPrograms(factories_to_add_with_vote[2].factory_addr)
+
+    reward_programs_registry = interface.RewardProgramsRegistry('0xfCaD241D9D2A2766979A2de208E8210eDf7b7D4F')
+    trusted_address = '0xe2A682A9722354D825d1BbDF372cC86B2ea82c8C'
+
+    add_reward_program_calldata = _encode_calldata(
+        "(address,string)", [
+            reward_program.address,
+            reward_program_title
+        ]
+    )
+
+    forked_motions = easy_track.getMotions()
+
+    tx = easy_track.createMotion(
+        add_reward_program,
+        add_reward_program_calldata,
+        {"from": trusted_address}
+    )
+
+    motions = easy_track.getMotions()
+    assert len(motions) == len(forked_motions) + 1
+
+    chain.sleep(72 * 60 * 60 + 100)
+
+    easy_track.enactMotion(
+        motions[len(motions) - 1][0],
+        tx.events["MotionCreated"]["_evmScriptCallData"],
+        {"from": stranger},
+    )
+    assert len(easy_track.getMotions()) == len(forked_motions)
+
+    reward_programs = reward_programs_registry.getRewardPrograms()
+    assert len(reward_programs) == 1
+    assert reward_programs[0] == reward_program
+
+    # create new motion to top up reward program
+    tx = easy_track.createMotion(
+        top_up_reward_programs,
+        encode_single("(address[],uint256[])", [[reward_program.address], [int(5e18)]]),
+        {"from": trusted_address},
+    )
+    motions = easy_track.getMotions()
+    assert len(motions) == len(forked_motions) + 1
+
+    chain.sleep(72 * 60 * 60 + 100)
+
+    assert ldo.balanceOf(reward_program) == 0
+
+    easy_track.enactMotion(
+        motions[len(motions) - 1][0],
+        tx.events["MotionCreated"]["_evmScriptCallData"],
+        {"from": stranger},
+    )
+
+    assert len(easy_track.getMotions()) == len(forked_motions)
+    assert ldo.balanceOf(reward_program) == 5e18
+
+    # create new motion to remove a reward program
+    tx = easy_track.createMotion(
+        remove_reward_program,
+        encode_single("(address)", [reward_program.address]),
+        {"from": trusted_address},
+    )
+
+    motions = easy_track.getMotions()
+    assert len(motions) == len(forked_motions) + 1
+
+    chain.sleep(72 * 60 * 60 + 100)
+
+    easy_track.enactMotion(
+        motions[len(motions) - 1][0],
+        tx.events["MotionCreated"]["_evmScriptCallData"],
+        {"from": stranger},
+    )
+    assert len(easy_track.getMotions()) == len(forked_motions)
+    assert len(reward_programs_registry.getRewardPrograms()) == 0

--- a/tests/tx_tracing_helpers.py
+++ b/tests/tx_tracing_helpers.py
@@ -27,8 +27,15 @@ def display_voting_call_trace(tx: TransactionReceipt) -> None:
                                                      'ScriptHelpers.']))
 
 
-def count_vote_items_by_events(tx: TransactionReceipt) -> int:
-    return EventDict(tx_events_from_trace(tx)).count('LogScriptCall')
+def count_vote_items_by_events(tx: TransactionReceipt, voting: Optional[str]) -> int:
+    events = tx_events_from_trace(tx)
+    ev_dict = EventDict(events)
+
+    if not voting:
+        return ev_dict.count('LogScriptCall')
+
+    calls_slice = ev_dict['LogScriptCall']
+    return sum(map(lambda x : x['src'] == voting, calls_slice))
 
 
 def display_voting_events(tx: TransactionReceipt) -> None:

--- a/utils/config.py
+++ b/utils/config.py
@@ -72,6 +72,10 @@ class ContractsLazyLoader:
         return interface.Lido(lido_dao_steth_address)
 
     @property
+    def ldo_token(self) -> interface.MiniMiToken:
+        return interface.MiniMiToken(ldo_token_address)
+
+    @property
     def voting(self) -> interface.Voting:
         return interface.Voting(lido_dao_voting_address)
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -32,7 +32,14 @@ else:
 
 
 def get_is_live() -> bool:
-    return network_name() != 'development'
+    dev_networks = [
+        "development",
+        "hardhat",
+        "hardhat-fork",
+        "mainnet-fork",
+        "goerli-fork"
+    ]
+    return network.show_active() not in dev_networks
 
 
 def get_deployer_account() -> Union[LocalAccount, Account]:
@@ -72,8 +79,8 @@ class ContractsLazyLoader:
         return interface.Lido(lido_dao_steth_address)
 
     @property
-    def ldo_token(self) -> interface.MiniMiToken:
-        return interface.MiniMiToken(ldo_token_address)
+    def ldo_token(self) -> interface.MiniMeToken:
+        return interface.MiniMeToken(ldo_token_address)
 
     @property
     def voting(self) -> interface.Voting:
@@ -110,6 +117,10 @@ class ContractsLazyLoader:
     @property
     def nos_app_repo(self) -> interface.Repo:
         return interface.Repo(lido_dao_node_operators_registry_repo)
+
+    @property
+    def easy_track(self) -> interface.EasyTrack:
+        return interface.EasyTrack(lido_easytrack)
 
 
 def __getattr__(name: str) -> Any:

--- a/utils/config_goerli.py
+++ b/utils/config_goerli.py
@@ -15,6 +15,7 @@ lido_dao_node_operators_registry_repo = '0x5f867429616b380f1ca7a7283ff18c53a0033
 lido_dao_kernel = '0x1dD91b354Ebd706aB3Ac7c727455C7BAA164945A'
 lido_dao_deposit_security_module_address = '0xed23ad3ea5fb9d10e7371caef1b141ad1c23a80c'
 
+lido_easytrack = '0xAf072C8D368E4DD4A9d4fF6A76693887d6ae92Af'
 lido_easytrack_evmscriptexecutor = '0x3c9AcA237b838c59612d79198685e7f20C7fE783'
 
 #Multisigs

--- a/utils/config_mainnet.py
+++ b/utils/config_mainnet.py
@@ -15,6 +15,7 @@ lido_dao_node_operators_registry_repo = '0x0D97E876ad14DB2b183CFeEB8aa1A5C788eB1
 lido_dao_kernel = '0xb8FFC3Cd6e7Cf5a098A1c92F48009765B24088Dc'
 lido_dao_deposit_security_module_address = '0xdb149235b6f40dc08810aa69869783be101790e7'
 
+lido_easytrack = '0xF0211b7660680B49De1A7E9f25C65660F0a13Fea'
 lido_easytrack_evmscriptexecutor = '0xFE5986E06210aC1eCC1aDCafc0cc7f8D63B3F977'
 
 # Multisigs

--- a/utils/easy_track.py
+++ b/utils/easy_track.py
@@ -1,0 +1,28 @@
+from typing import Tuple
+from utils.config import contracts
+
+from brownie import Contract
+
+def add_evmscript_factory(factory: Contract, permissions: str) -> Tuple[str, str]:
+    easy_track = contracts.easy_track
+
+    return (
+        easy_track.address,
+        easy_track.addEVMScriptFactory.encode_input(
+            factory,
+            permissions
+        )
+    )
+
+def remove_evmscript_factory(factory: Contract) -> Tuple[str, str]:
+    easy_track = contracts.easy_track
+
+    return (
+        easy_track.address,
+        easy_track.removeEVMScriptFactory.encode_input(
+            factory
+        )
+    )
+
+def create_permissions(contract: Contract, method: str) -> str:
+    return contract.address + getattr(contract, method).signature[2:]


### PR DESCRIPTION
Omnibus 24/03/2022 voting items:
1. Add AddRewardProgram 0x929547490Ceb6AeEdD7d72F1Ab8957c0210b6E51 factory to Easy Track
2. Add RemoveRewardProgram 0xE9eb838fb3A288bF59E9275Ccd7e124fDff88a9C factory to Easy Track
3. Add TopUpRewardPrograms 0x54058ee0E0c87Ad813C002262cD75B98A7F59218 factory to Easy Track
4. Send 350,000 LDO to 0x3A043ce95876683768D3D3FB80057be2ee3f2814 for Hyperelliptic & RockX
   team for Lido-on-Avalanache comps
5. Pass ownership of the 1inch rewarder 0xf5436129Cf9d8fa2a1cb6e591347155276550635
   to TokensRecoverer 0x1bdfFe0EBef3FEAdF2723D3330727D73f538959C
6. Recover LDO funds from the 1inch rewarder 0xf5436129cf9d8fa2a1cb6e591347155276550635
   to DAO Agent.
