### PR TITLE
Feat: add voting scripts to issue & assign vested LDOs

### DIFF
--- a/scripts/vote_recover_vesting.py
+++ b/scripts/vote_recover_vesting.py
@@ -1,0 +1,118 @@
+"""
+Voting *TBA*.
+
+1. Create role ISSUE_ROLE for TokenManager 0xDfe76d11b365f5e0023343A367f0b311701B3bc1
+2. Issue 3,691,500 LDO tokens in favor of TokenManager 0xDfe76d11b365f5e0023343A367f0b311701B3bc1
+3. Assign vested 3,691,500 LDO tokens to 0x... *TBA* till Sun Dec 18 2022 00:00:00 +UTC
+4. Revoke ISSUE_ROLE from Voting 0xbc0B67b4553f4CF52a913DE9A6eD0057E2E758Db
+
+#FIXME: replace all TBAs and addresses
+
+"""
+
+import time
+
+from typing import (Dict, Tuple, Optional)
+
+from brownie.network.transaction import TransactionReceipt
+
+from utils.voting import confirm_vote_script, create_vote
+from utils.permissions import encode_permission_revoke, create_permission
+from utils.evm_script import encode_call_script
+from utils.config import get_deployer_account, contracts
+
+from utils.brownie_prelude import *
+
+def issue_ldo(
+    amount: int,
+) -> Tuple[str, str]:
+    token_manager: interface.TokenManager = contracts.token_manager
+
+    return (
+        token_manager.address,
+        token_manager.issue.encode_input(
+            amount
+        )
+    )
+
+def assign_vested(
+    target_address: str,
+    amount: int,
+    start: int,
+    cliff: int,
+    vesting: int
+) -> Tuple[str, str]:
+    token_manager: interface.TokenManager = contracts.token_manager
+    revokable: bool = False
+
+    return (
+        token_manager.address,
+        token_manager.assignVested.encode_input(
+            target_address,
+            amount,
+            start,
+            cliff,
+            vesting,
+            revokable
+        )
+    )
+
+def start_vote(
+    tx_params: Dict[str, str],
+    silent: bool = False
+) -> Tuple[int, Optional[TransactionReceipt]]:
+    """Prepare and run voting."""
+
+    token_manager: interface.TokenManager = contracts.token_manager
+    voting: interface.Voting = contracts.voting
+    acl: interface.ACL = contracts.acl
+
+    ldo_amount: int = 3_691_500 * 10 ** 18
+    destination_vesting_address: str = '0x1bdfFe0EBef3FEAdF2723D3330727D73f538959C' #FIXME: insert proper address
+
+    #FIXME: The numbers need to be updated
+    # see also https://www.unixtimestamp.com/index.php for time conversions
+    start: int = 1639785600   # Sat Dec 18 2021 00:00:00 GMT+0000 (3 months ago)
+    cliff: int = 1639785600   # Sat Dec 18 2021 00:00:00 GMT+0000 (3 months ago)
+    vesting: int = 1671321600 # Sun Dec 18 2022 00:00:00 GMT+0000 (in 9 months)
+
+    encoded_call_script = encode_call_script([
+        # 1. Create role ISSUE_ROLE for TokenManager 0xDfe76d11b365f5e0023343A367f0b311701B3bc1
+        create_permission(entity=voting, target_app=token_manager, permission_name='ISSUE_ROLE', manager=voting, acl=acl),
+        # 2. Issue 3,691,500 LDO tokens in favor of TokenManager 0xDfe76d11b365f5e0023343A367f0b311701B3bc1
+        issue_ldo(ldo_amount),
+        # 3. Assign vested 3,691,500 LDO tokens to 0x... till Sun Dec 18 2022 00:00:00 +UTC
+        assign_vested(
+            destination_vesting_address,
+            ldo_amount,
+            start=start,
+            cliff=cliff,
+            vesting=vesting
+        ),
+        # 4. Revoke ISSUE_ROLE from Voting 0xbc0B67b4553f4CF52a913DE9A6eD0057E2E758Db
+        encode_permission_revoke(target_app=token_manager, permission_name='ISSUE_ROLE', revoke_from=voting, acl=acl),
+    ])
+
+    return confirm_vote_script(encoded_call_script, silent) and create_vote(
+        vote_desc=(
+            'Omnibus vote: '
+            '1) Create role ISSUE_ROLE for TokenManager 0xDfe76d11b365f5e0023343A367f0b311701B3bc1;'
+            '2) Issue 3,691,500 LDO tokens in favor of TokenManager 0xDfe76d11b365f5e0023343A367f0b311701B3bc1;'
+            '3) Assign vested 3,691,500 LDO tokens to 0x... till Sun Dec 18 2022 00:00:00 +UTC;'
+            '4) Revoke ISSUE_ROLE from Voting 0xbc0B67b4553f4CF52a913DE9A6eD0057E2E758Db.'
+        ),
+        evm_script=encoded_call_script,
+        tx_params=tx_params
+    )
+
+
+def main():
+    vote_id, _ = start_vote({
+        'from': get_deployer_account(),
+        'max_fee': '300 gwei',
+        'priority_fee': '2 gwei'
+    })
+
+    vote_id >= 0 and print(f'Vote created: {vote_id}.')
+
+    time.sleep(5)  # hack for waiting thread #2.

--- a/tests/event_validators/permission.py
+++ b/tests/event_validators/permission.py
@@ -12,11 +12,28 @@ class Permission(NamedTuple):
     app: str
     role: str
 
+def validate_permission_create_event(event: EventDict, p: Permission) -> None:
+    _events_chain = ['LogScriptCall', 'SetPermission', 'ChangePermissionManager']
 
-def validate_permission_revoke_event(event: EventDict, p: Permission):
-    _ldo_events_chain = ['LogScriptCall', 'SetPermission']
+    validate_events_chain([e.name for e in event], _events_chain)
 
-    validate_events_chain([e.name for e in event], _ldo_events_chain)
+    assert event.count('LogScriptCall') == 1
+    assert event.count('SetPermission') == 1
+    assert event.count('ChangePermissionManager') == 1
+
+    assert event['SetPermission']['entity'] == p.entity, "Wrong entity"
+    assert event['SetPermission']['app'] == p.app, "Wrong app address"
+    assert event['SetPermission']['role'] == p.role, "Wrong role"
+    assert event['SetPermission']['allowed'] is True, "Wrong role"
+
+    assert event['ChangePermissionManager']['app'] == p.app, "Wrong app address"
+    assert event['ChangePermissionManager']['role'] == p.role, "Wrong role"
+    assert event['ChangePermissionManager']['manager'] == p.entity, "Wring entity"
+
+def validate_permission_revoke_event(event: EventDict, p: Permission) -> None:
+    _events_chain = ['LogScriptCall', 'SetPermission']
+
+    validate_events_chain([e.name for e in event], _events_chain)
 
     assert event.count('SetPermission') == 1
 
@@ -26,10 +43,10 @@ def validate_permission_revoke_event(event: EventDict, p: Permission):
     assert event['SetPermission']['allowed'] is False, "Wrong role"
 
 
-def validate_permission_grantp_event(event: EventDict, p: Permission, params: List[Param]):
-    _ldo_events_chain = ['LogScriptCall', 'SetPermission', 'SetPermissionParams']
+def validate_permission_grantp_event(event: EventDict, p: Permission, params: List[Param]) -> None:
+    _events_chain = ['LogScriptCall', 'SetPermission', 'SetPermissionParams']
 
-    validate_events_chain([e.name for e in event], _ldo_events_chain)
+    validate_events_chain([e.name for e in event], _events_chain)
 
     assert event.count('SetPermission') == 1
 

--- a/tests/event_validators/token_manager.py
+++ b/tests/event_validators/token_manager.py
@@ -1,0 +1,44 @@
+from typing import NamedTuple
+from brownie import ZERO_ADDRESS
+
+from brownie.network.event import EventDict
+from .common import validate_events_chain
+
+class Issue(NamedTuple):
+    token_manager_addr: str
+    amount: int
+
+class Vested(NamedTuple):
+    destination_addr: str
+    amount: int
+    start: int
+    cliff: int
+    vesting: int
+    revokable: bool
+
+def validate_ldo_issue_event(event: EventDict, i: Issue):
+    _events_chain = ['LogScriptCall', 'Transfer']
+
+    validate_events_chain([e.name for e in event], _events_chain)
+
+    assert event.count('LogScriptCall') == 1
+    assert event.count('Transfer') == 1
+
+    assert event['Transfer']['from'] == ZERO_ADDRESS, "Wrong from field"
+    assert event['Transfer']['to'] == i.token_manager_addr
+    assert event['Transfer']['value'] == i.amount
+
+def validate_ldo_vested_event(event: EventDict, v: Vested):
+    _events_chain = ['LogScriptCall', 'Transfer', 'NewVesting']
+
+    assert event.count('LogScriptCall') == 1
+    assert event.count('Transfer') == 1
+    assert event.count('NewVesting') == 1
+
+    validate_events_chain([e.name for e in event], _events_chain)
+
+    assert event['Transfer']['to'] == v.destination_addr
+    assert event['Transfer']['value'] == v.amount
+
+    assert event['NewVesting']['receiver'] == v.destination_addr
+    assert event['NewVesting']['amount'] == v.amount

--- a/tests/test_recover_vesting.py
+++ b/tests/test_recover_vesting.py
@@ -1,0 +1,111 @@
+"""
+Tests for voting *TBA*.
+"""
+from scripts.vote_recover_vesting import start_vote
+
+from event_validators.permission import (
+    validate_permission_create_event,
+    validate_permission_revoke_event,
+    Permission
+)
+
+from event_validators.token_manager import (
+    validate_ldo_issue_event,
+    validate_ldo_vested_event,
+    Issue,
+    Vested
+)
+
+from tx_tracing_helpers import *
+from utils.permissions import create_permission
+
+ldo_amount: int = 3_691_500 * 10 ** 18
+lido_dao_token: str = '0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32'
+destination_address: str = '0x1bdfFe0EBef3FEAdF2723D3330727D73f538959C' #FIXME: insert the proper addres
+
+create_permission: Permission = Permission(
+    entity='0x2e59A20f205bB85a89C53f1936454680651E618e', # Voting
+    app='0xf73a1260d222f447210581DDf212D915c09a3249', # Token Manager
+    role='0x2406f1e99f79cea012fb88c5c36566feaeefee0f4b98d3a376b49310222b53c4' # keccak256('ISSUE_ROLE')
+)
+
+revoke_permission: Permission = create_permission
+
+issue: Issue = Issue(
+    token_manager_addr=create_permission.app,
+    amount=ldo_amount
+)
+
+vested: Vested = Vested(
+    destination_addr=destination_address,
+    amount=ldo_amount,
+    start=1639785600,
+    cliff=1639785600,
+    vesting=1671321600,
+    revokable=False
+)
+
+def test_ldo_recover(
+    helpers, accounts, ldo_holder, dao_voting,
+    ldo_token, dao_token_manager, acl,
+    vote_id_from_env, bypass_events_decoding
+):
+    total_supply_before = ldo_token.totalSupply()
+    destination_balance_before = ldo_token.balanceOf(destination_address)
+    token_manager_balance_before = ldo_token.balanceOf(dao_token_manager)
+
+    vestings_before = dao_token_manager.vestingsLengths(destination_address)
+
+    assert not acl.hasPermission(dao_voting, dao_token_manager, dao_token_manager.ISSUE_ROLE())
+
+    ##
+    ## START VOTE
+    ##
+    vote_id = vote_id_from_env or start_vote({'from': ldo_holder}, silent=True)[0]
+
+    tx: TransactionReceipt = helpers.execute_vote(
+        vote_id=vote_id, accounts=accounts, dao_voting=dao_voting, skip_time=3 * 60 * 60 * 24
+    )
+
+    total_supply_after = ldo_token.totalSupply()
+    destination_balance_after = ldo_token.balanceOf(destination_address)
+    token_manager_balance_after = ldo_token.balanceOf(dao_token_manager)
+
+    vestings_after = dao_token_manager.vestingsLengths(destination_address)
+    assigned_vesting = dao_token_manager.getVesting(destination_address, vestings_before)
+
+    assert assigned_vesting['amount'] == vested.amount
+    assert assigned_vesting['start'] == vested.start
+    assert assigned_vesting['cliff'] == vested.cliff
+    assert assigned_vesting['vesting'] == vested.vesting
+    assert assigned_vesting['revokable'] == vested.revokable
+
+    assert total_supply_after == total_supply_before + ldo_amount, "Incorrect total supply"
+    assert total_supply_after == 1_000_000_000 * 10 ** 18
+    assert destination_balance_after == destination_balance_before + ldo_amount, "Incorrect LDO amount"
+    assert token_manager_balance_before == token_manager_balance_after, "Incorrect LDO amount"
+    assert vestings_after == vestings_before + 1, "Incorrect vestings length"
+
+    assert not acl.hasPermission(dao_voting, dao_token_manager, dao_token_manager.ISSUE_ROLE())
+
+    ### validate vote events
+    assert count_vote_items_by_events(tx, dao_voting) == 4, "Incorrect voting items count"
+
+    display_voting_events(tx)
+
+    if bypass_events_decoding:
+        return
+
+    evs = group_voting_events(tx)
+
+    # asserts on vote item 1
+    validate_permission_create_event(evs[0], create_permission)
+
+    # asserts on vote item 2
+    validate_ldo_issue_event(evs[1], issue)
+
+    # asserts on vote item 3
+    validate_ldo_vested_event(evs[2], vested)
+
+    # asserts on vote item 4
+    validate_permission_revoke_event(evs[3], revoke_permission)


### PR DESCRIPTION
The voting script covers the following proposed actions:

1. Create role ISSUE_ROLE for TokenManager 0xDfe76d11b365f5e0023343A367f0b311701B3bc1
2. Issue 3,691,500 LDO tokens in favor of TokenManager 0xDfe76d11b365f5e0023343A367f0b311701B3bc1
3. Assign vested 3,691,500 LDO tokens to 0x... *TBA* till *TBA*
4. Revoke ISSUE_ROLE from Voting 0xbc0B67b4553f4CF52a913DE9A6eD0057E2E758Db

Context: https://research.lido.fi/t/proposal-to-freeze-vesting-for-compromised-address/1864
See also: https://github.com/lidofinance/scripts/pull/39
