### PR TITLE
Feat: add voting on 2022/04/12

### DIFF
--- a/scripts/vote_2022_04_12.py
+++ b/scripts/vote_2022_04_12.py
@@ -3,7 +3,7 @@ Voting 12/04/2022.
 
 1. Refund previous depositor' spending to finance multisig 0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb
    with 254.684812629886507249 ETH.
-2. Fund dedicated depositor multisig 0x5181d5D56Af4f823b96FE05f062D7a09761a5a53 with 130 ETH.
+2. Fund depositor bot with 130 ETH.
 
 """
 
@@ -37,9 +37,9 @@ def start_vote(
         ),
         # 2. Fund dedicated depositor multisig 0x5181d5D56Af4f823b96FE05f062D7a09761a5a53 with 130 ETH.
         make_eth_payout(
-            target_address='0x5181d5D56Af4f823b96FE05f062D7a09761a5a53',
+            target_address='0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb',
             eth_in_wei=130 * (10 ** 18),
-            reference='Fund depositor\'s multisig'
+            reference='Fund depositor bot'
         ),
     ])
 
@@ -47,7 +47,7 @@ def start_vote(
         vote_desc=(
             'Omnibus vote: '
             '1) Refund previous depositor\' spending to finance multisig with 254.684812629886507249 ETH; '
-            '2) Fund dedicated depositor multisig 0x5181d5D56Af4f823b96FE05f062D7a09761a5a53 with 130 ETH.'
+            '2) Fund depositor bot with 130 ETH.'
         ),
         evm_script=encoded_call_script,
         tx_params=tx_params

--- a/scripts/vote_2022_04_12.py
+++ b/scripts/vote_2022_04_12.py
@@ -1,0 +1,68 @@
+"""
+Voting 12/04/2022.
+
+1. Refund previous depositor' spending to finance multisig 0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb
+   with 254.684812629886507249 ETH.
+2. Fund dedicated depositor multisig 0x5181d5D56Af4f823b96FE05f062D7a09761a5a53 with 130 ETH.
+
+"""
+
+import time
+
+from typing import (Dict, Tuple, Optional)
+
+from brownie.network.transaction import TransactionReceipt
+
+from utils.voting import confirm_vote_script, create_vote
+from utils.finance import make_eth_payout
+from utils.evm_script import encode_call_script
+from utils.config import (
+    get_deployer_account,
+    get_is_live
+)
+
+def start_vote(
+    tx_params: Dict[str, str],
+    silent: bool = False
+) -> Tuple[int, Optional[TransactionReceipt]]:
+    """Prepare and run voting."""
+
+    encoded_call_script = encode_call_script([
+        # 1. Refund previous depositor' spending to finance multisig 0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb
+        # with 254.684812629886507249 ETH.
+        make_eth_payout(
+            target_address='0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb',
+            eth_in_wei=254_684_812_629_886_507_249,
+            reference='Refund depositor\'s spending'
+        ),
+        # 2. Fund dedicated depositor multisig 0x5181d5D56Af4f823b96FE05f062D7a09761a5a53 with 130 ETH.
+        make_eth_payout(
+            target_address='0x5181d5D56Af4f823b96FE05f062D7a09761a5a53',
+            eth_in_wei=130 * (10 ** 18),
+            reference='Fund depositor\'s multisig'
+        ),
+    ])
+
+    return confirm_vote_script(encoded_call_script, silent) and create_vote(
+        vote_desc=(
+            'Omnibus vote: '
+            '1) Refund previous depositor\' spending to finance multisig with 254.684812629886507249 ETH; '
+            '2) Fund dedicated depositor multisig 0x5181d5D56Af4f823b96FE05f062D7a09761a5a53 with 130 ETH.'
+        ),
+        evm_script=encoded_call_script,
+        tx_params=tx_params
+    )
+
+
+def main():
+    tx_params = {'from': get_deployer_account()}
+
+    if get_is_live():
+        tx_params['max_fee'] = '300 gwei'
+        tx_params['priority_fee'] = '2 gwei'
+
+    vote_id, _ = start_vote(tx_params=tx_params)
+
+    vote_id >= 0 and print(f'Vote created: {vote_id}.')
+
+    time.sleep(5)  # hack for waiting thread #2.

--- a/scripts/vote_2022_04_12.py
+++ b/scripts/vote_2022_04_12.py
@@ -2,8 +2,8 @@
 Voting 12/04/2022.
 
 1. Refund previous depositor' spending to finance multisig 0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb
-   with 254.684812629886507249 ETH.
-2. Fund depositor bot with 130 ETH.
+   with 254.684812629886507249 stETH.
+2. Fund depositor bot multisig 0x5181d5D56Af4f823b96FE05f062D7a09761a5a53 with 130 stETH.
 
 """
 
@@ -14,7 +14,7 @@ from typing import (Dict, Tuple, Optional)
 from brownie.network.transaction import TransactionReceipt
 
 from utils.voting import confirm_vote_script, create_vote
-from utils.finance import make_eth_payout
+from utils.finance import make_steth_payout
 from utils.evm_script import encode_call_script
 from utils.config import (
     get_deployer_account,
@@ -29,25 +29,25 @@ def start_vote(
 
     encoded_call_script = encode_call_script([
         # 1. Refund previous depositor' spending to finance multisig 0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb
-        # with 254.684812629886507249 ETH.
-        make_eth_payout(
+        # with 254.684812629886507249 stETH.
+        make_steth_payout(
             target_address='0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb',
-            eth_in_wei=254_684_812_629_886_507_249,
+            steth_in_wei=254_684_812_629_886_507_249,
             reference='Refund depositor\'s spending'
         ),
-        # 2. Fund dedicated depositor multisig 0x5181d5D56Af4f823b96FE05f062D7a09761a5a53 with 130 ETH.
-        make_eth_payout(
-            target_address='0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb',
-            eth_in_wei=130 * (10 ** 18),
-            reference='Fund depositor bot'
+        # 2. Fund dedicated depositor multisig 0x5181d5D56Af4f823b96FE05f062D7a09761a5a53 with 130 stETH.
+        make_steth_payout(
+            target_address='0x5181d5D56Af4f823b96FE05f062D7a09761a5a53',
+            steth_in_wei=130 * (10 ** 18),
+            reference='Fund depositor bot multisig'
         ),
     ])
 
     return confirm_vote_script(encoded_call_script, silent) and create_vote(
         vote_desc=(
             'Omnibus vote: '
-            '1) Refund previous depositor\' spending to finance multisig with 254.684812629886507249 ETH; '
-            '2) Fund depositor bot with 130 ETH.'
+            '1) Refund previous depositor\' spending to finance multisig with 254.684812629886507249 stETH; '
+            '2) Fund depositor bot multisig 0x5181d5D56Af4f823b96FE05f062D7a09761a5a53 with 130 stETH.'
         ),
         evm_script=encoded_call_script,
         tx_params=tx_params

--- a/tests/event_validators/payout.py
+++ b/tests/event_validators/payout.py
@@ -13,7 +13,7 @@ class Payout(NamedTuple):
     amount: int
 
 
-def validate_payout_event(event: EventDict, p: Payout):
+def validate_token_payout_event(event: EventDict, p: Payout):
     _ldo_events_chain = ['LogScriptCall', 'NewPeriod', 'NewTransaction', 'Transfer', 'VaultTransfer']
 
     validate_events_chain([e.name for e in event], _ldo_events_chain)
@@ -29,6 +29,21 @@ def validate_payout_event(event: EventDict, p: Payout):
     assert event['Transfer']['to'] == p.to_addr, "Wrong payout destination ('to')"
     assert event['Transfer']['value'] == p.amount, "Wrong payout amount"
     assert event['Transfer']['from'] == p.from_addr, "Wrong payout source ('from')"
+
+    assert event['NewTransaction']['entity'] == p.to_addr
+    assert event['NewTransaction']['amount'] == p.amount
+
+def validate_ether_payout_event(event: EventDict, p: Payout):
+    _ldo_events_chain = ['LogScriptCall', 'NewPeriod', 'NewTransaction', 'VaultTransfer']
+
+    validate_events_chain([e.name for e in event], _ldo_events_chain)
+
+    assert event.count('VaultTransfer') == 1
+    assert event.count('NewTransaction') == 1
+
+    assert event['VaultTransfer']['token'] == p.token_addr, "Wrong payout token"
+    assert event['VaultTransfer']['to'] == p.to_addr, "Wrong payout destination ('to')"
+    assert event['VaultTransfer']['amount'] == p.amount, "Wrong payout amount"
 
     assert event['NewTransaction']['entity'] == p.to_addr
     assert event['NewTransaction']['amount'] == p.amount

--- a/tests/test_2022_04_12.py
+++ b/tests/test_2022_04_12.py
@@ -1,0 +1,68 @@
+"""
+Tests for voting 12/04/2022.
+"""
+
+from event_validators.payout import Payout, validate_payout_event
+
+from utils.finance import ZERO_ADDRESS
+from scripts.vote_2022_04_12 import start_vote
+from tx_tracing_helpers import *
+
+finance_multisig_address = '0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb'
+depositor_multisig_address = '0x5181d5D56Af4f823b96FE05f062D7a09761a5a53'
+dao_agent_address = '0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c'
+
+refund_payout = Payout(
+    token_addr=ZERO_ADDRESS,
+    from_addr=dao_agent_address,
+    to_addr=finance_multisig_address,
+    amount=254_684_812_629_886_507_249
+)
+
+fund_payout = Payout(
+    token_addr=ZERO_ADDRESS,
+    from_addr=dao_agent_address,
+    to_addr=depositor_multisig_address,
+    amount=130 * (10 ** 18)
+)
+
+def test_2022_04_12(
+    helpers, accounts, ldo_holder, dao_voting,
+    vote_id_from_env, bypass_events_decoding
+):
+    finance_multisig_balance_before = accounts.at(finance_multisig_address, force=True)
+    depositor_multisig_balance_before = accounts.at(depositor_multisig_address, force=True)
+    dao_balance_before = accounts.at(dao_agent_address, force=True)
+
+    ##
+    ## START VOTE
+    ##
+    vote_id = vote_id_from_env or start_vote({'from': ldo_holder}, silent=True)[0]
+
+    tx: TransactionReceipt = helpers.execute_vote(
+        vote_id=vote_id, accounts=accounts, dao_voting=dao_voting
+    )
+
+    finance_multisig_balance_after = accounts.at(finance_multisig_address, force=True)
+    depositor_multisig_balance_after = accounts.at(depositor_multisig_address, force=True)
+    dao_balance_after = accounts.at(dao_agent_address, force=True)
+
+    assert finance_multisig_balance_after - finance_multisig_balance_before == refund_payout.amount
+    assert depositor_multisig_balance_after - depositor_multisig_balance_before == fund_payout.amount
+    assert dao_balance_after - dao_balance_before == refund_payout.amount + fund_payout.amount
+
+    ### validate vote events
+    assert count_vote_items_by_events(tx) == 2, "Incorrect voting items count"
+
+    display_voting_events(tx)
+
+    if bypass_events_decoding:
+        return
+
+    evs = group_voting_events(tx)
+
+    # asserts on vote item 1
+    validate_payout_event(evs[0], refund_payout)
+
+    # asserts on vote item 2
+    validate_payout_event(evs[1], fund_payout)

--- a/tests/test_2022_04_12.py
+++ b/tests/test_2022_04_12.py
@@ -4,42 +4,41 @@ Tests for voting 12/04/2022.
 
 from event_validators.payout import (
     Payout,
-    validate_ether_payout_event
+    validate_token_payout_event
 )
 
-from utils.finance import ZERO_ADDRESS
 from scripts.vote_2022_04_12 import start_vote
 from tx_tracing_helpers import *
 
 finance_multisig_address = '0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb'
 depositor_multisig_address = '0x5181d5D56Af4f823b96FE05f062D7a09761a5a53'
 dao_agent_address = '0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c'
+steth_address = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84'
+
+def steth_balance_checker(lhs_value: int, rhs_value: int):
+    assert (lhs_value + 9) // 10 == (rhs_value + 9) // 10
 
 refund_payout = Payout(
-    token_addr=ZERO_ADDRESS,
+    token_addr=steth_address,
     from_addr=dao_agent_address,
     to_addr=finance_multisig_address,
     amount=254_684_812_629_886_507_249
 )
 
 fund_payout = Payout(
-    token_addr=ZERO_ADDRESS,
+    token_addr=steth_address,
     from_addr=dao_agent_address,
-    to_addr=finance_multisig_address,
+    to_addr=depositor_multisig_address,
     amount=130 * (10 ** 18)
 )
 
 def test_2022_04_12(
-    helpers, accounts, ldo_holder, dao_voting,
+    helpers, accounts, ldo_holder, dao_voting, lido,
     vote_id_from_env, bypass_events_decoding
 ):
-    finance_multisig_account = accounts.at(finance_multisig_address, force=True)
-    depositor_multisig_account = accounts.at(depositor_multisig_address, force=True)
-    dao_agent_account = accounts.at(dao_agent_address, force=True)
-
-    finance_multisig_balance_before = finance_multisig_account.balance()
-    depositor_multisig_balance_before = depositor_multisig_account.balance()
-    dao_balance_before = dao_agent_account.balance()
+    finance_multisig_balance_before = lido.balanceOf(finance_multisig_address)
+    depositor_multisig_balance_before = lido.balanceOf(depositor_multisig_address)
+    dao_balance_before = lido.balanceOf(dao_agent_address)
 
     ##
     ## START VOTE
@@ -50,13 +49,13 @@ def test_2022_04_12(
         vote_id=vote_id, accounts=accounts, dao_voting=dao_voting, topup='0.5 ether'
     )
 
-    finance_multisig_balance_after = finance_multisig_account.balance()
-    depositor_multisig_balance_after = depositor_multisig_account.balance()
-    dao_balance_after = dao_agent_account.balance()
+    finance_multisig_balance_after = lido.balanceOf(finance_multisig_address)
+    depositor_multisig_balance_after = lido.balanceOf(depositor_multisig_address)
+    dao_balance_after = lido.balanceOf(dao_agent_address)
 
-    assert finance_multisig_balance_after - finance_multisig_balance_before == refund_payout.amount + fund_payout.amount
-    assert dao_balance_before - dao_balance_after == refund_payout.amount + fund_payout.amount - 5 * (10 ** 17)
-    assert depositor_multisig_balance_before == depositor_multisig_balance_after
+    steth_balance_checker(finance_multisig_balance_after - finance_multisig_balance_before, refund_payout.amount)
+    steth_balance_checker(depositor_multisig_balance_after - depositor_multisig_balance_before, fund_payout.amount)
+    steth_balance_checker(dao_balance_before - dao_balance_after, refund_payout.amount + fund_payout.amount)
 
     ### validate vote events
     assert count_vote_items_by_events(tx) == 2, "Incorrect voting items count"
@@ -69,7 +68,7 @@ def test_2022_04_12(
     evs = group_voting_events(tx)
 
     # asserts on vote item 1
-    validate_ether_payout_event(evs[0], refund_payout)
+    validate_token_payout_event(evs[0], refund_payout)
 
     # asserts on vote item 2
-    validate_ether_payout_event(evs[1], fund_payout)
+    validate_token_payout_event(evs[1], fund_payout)

--- a/tests/test_2022_04_12.py
+++ b/tests/test_2022_04_12.py
@@ -30,9 +30,13 @@ def test_2022_04_12(
     helpers, accounts, ldo_holder, dao_voting,
     vote_id_from_env, bypass_events_decoding
 ):
-    finance_multisig_balance_before = accounts.at(finance_multisig_address, force=True)
-    depositor_multisig_balance_before = accounts.at(depositor_multisig_address, force=True)
-    dao_balance_before = accounts.at(dao_agent_address, force=True)
+    finance_multisig_account = accounts.at(finance_multisig_address, force=True)
+    depositor_multisig_account = accounts.at(depositor_multisig_address, force=True)
+    dao_agent_account = accounts.at(dao_agent_address, force=True)
+
+    finance_multisig_balance_before = finance_multisig_account.balance()
+    depositor_multisig_balance_before = depositor_multisig_account.balance()
+    dao_balance_before = dao_agent_account.balance()
 
     ##
     ## START VOTE
@@ -43,9 +47,9 @@ def test_2022_04_12(
         vote_id=vote_id, accounts=accounts, dao_voting=dao_voting
     )
 
-    finance_multisig_balance_after = accounts.at(finance_multisig_address, force=True)
-    depositor_multisig_balance_after = accounts.at(depositor_multisig_address, force=True)
-    dao_balance_after = accounts.at(dao_agent_address, force=True)
+    finance_multisig_balance_after = finance_multisig_account.balance()
+    depositor_multisig_balance_after = depositor_multisig_account.balance()
+    dao_balance_after = dao_agent_account.balance()
 
     assert finance_multisig_balance_after - finance_multisig_balance_before == refund_payout.amount
     assert depositor_multisig_balance_after - depositor_multisig_balance_before == fund_payout.amount

--- a/utils/finance.py
+++ b/utils/finance.py
@@ -6,7 +6,47 @@ from utils.config import (contracts, ldo_token_address)
 ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 
-def encode_token_transfer(token_address, recipient, amount, reference, finance):
+def make_ldo_payout(
+    *not_specified,
+    target_address: str,
+    ldo_in_wei: int,
+    reference: str
+) -> Tuple[str, str]:
+    """Encode LDO payout."""
+    if not_specified:
+        raise ValueError(
+            'Please, specify all arguments with keywords.'
+        )
+
+    return _encode_token_transfer(
+        token_address=ldo_token_address,
+        recipient=target_address,
+        amount=ldo_in_wei,
+        reference=reference,
+        finance=contracts.finance
+    )
+
+def make_eth_payout(
+    *not_specified,
+    target_address: str,
+    eth_in_wei: int,
+    reference: str
+) -> Tuple[str, str]:
+    """Encode ETH payout."""
+    if not_specified:
+        raise ValueError(
+            'Please, specify all arguments with keywords.'
+        )
+
+    return _encode_eth_transfer(
+        recipient=target_address,
+        amount=eth_in_wei,
+        reference=reference,
+        finance=contracts.finance
+    )
+
+
+def _encode_token_transfer(token_address, recipient, amount, reference, finance):
     return (
         finance.address,
         finance.newImmediatePayment.encode_input(
@@ -21,7 +61,7 @@ def encode_token_transfer(token_address, recipient, amount, reference, finance):
 # aragonOS and aragon-apps rely on address(0) to denote native ETH, in
 # contracts where both tokens and ETH are accepted
 # from https://github.com/aragon/aragonOS/blob/master/contracts/common/EtherTokenConstant.sol
-def encode_eth_transfer(recipient, amount, reference, finance):
+def _encode_eth_transfer(recipient, amount, reference, finance):
     return (
         finance.address,
         finance.newImmediatePayment.encode_input(
@@ -30,25 +70,4 @@ def encode_eth_transfer(recipient, amount, reference, finance):
             amount,
             reference
         )
-    )
-
-
-def make_ldo_payout(
-        *not_specified,
-        target_address: str,
-        ldo_in_wei: int,
-        reference: str
-) -> Tuple[str, str]:
-    """Encode LDO payout."""
-    if not_specified:
-        raise ValueError(
-            'Please, specify all arguments with keywords.'
-        )
-
-    return encode_token_transfer(
-        token_address=ldo_token_address,
-        recipient=target_address,
-        amount=ldo_in_wei,
-        reference=reference,
-        finance=contracts.finance
     )

--- a/utils/finance.py
+++ b/utils/finance.py
@@ -1,7 +1,7 @@
 
 from typing import Tuple
 
-from utils.config import (contracts, ldo_token_address)
+from utils.config import (contracts, ldo_token_address, lido_dao_steth_address)
 
 ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
@@ -22,6 +22,26 @@ def make_ldo_payout(
         token_address=ldo_token_address,
         recipient=target_address,
         amount=ldo_in_wei,
+        reference=reference,
+        finance=contracts.finance
+    )
+
+def make_steth_payout(
+    *not_specified,
+    target_address: str,
+    steth_in_wei: int,
+    reference: str
+) -> Tuple[str, str]:
+    """Encode stETH payout."""
+    if not_specified:
+        raise ValueError(
+            'Please, specify all arguments with keywords.'
+        )
+
+    return _encode_token_transfer(
+        token_address=lido_dao_steth_address,
+        recipient=target_address,
+        amount=steth_in_wei,
         reference=reference,
         finance=contracts.finance
     )


### PR DESCRIPTION
Voting points:
1. Refund previous depositor' spending to finance multisig 0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb
   with 254.684812629886507249 stETH.
2. Fund dedicated depositor multisig 0x5181d5D56Af4f823b96FE05f062D7a09761a5a53 with 130 stETH.

Context:
1. Refund https://snapshot.org/#/lido-snapshot.eth/proposal/0x13bb40e199529c3bc725b8a12f3a946555fc0684bb48a16e3b38c0a6568d8b02 
2. Fund https://snapshot.org/#/lido-snapshot.eth/proposal/0x712919976dc89777faecda7b346713664498fe572542f767e19cf9aa4f9fd7ae