### PR TITLE
Remove excess config addresses output

### DIFF
--- a/utils/voting.py
+++ b/utils/voting.py
@@ -34,7 +34,7 @@ def create_vote(
     tx_params: Dict[str, str],
     verbose: bool = False,
     cast_vote: bool = False,
-    executes_if_decided: bool = False
+    executes_if_decided: bool = False,
 ) -> Tuple[int, Optional[TransactionReceipt]]:
     vote_desc_str = ""
     for v in vote_items.keys():
@@ -119,20 +119,13 @@ def confirm_vote_script(vote_items: Dict[str, Tuple[str, str]], silent: bool) ->
 
     # Show detailed description of prepared voting.
     if not silent:
-        vote_descs = list(vote_items.keys())
-        cfg_params = get_config_params()
-
-        config_repr = "All known addresses extracted from a config file:\n"
-        for k, v in cfg_params.items():
-            config_repr += f"{k} => {v}\n"
-        config_repr = color.highlight(config_repr)
-        print(f"{config_repr}")
+        vote_descriptions = list(vote_items.keys())
 
         print("\nPoints of voting:")
         total = len(human_readable_script)
         for ind, call in enumerate(human_readable_script):
             print(f"Point #{ind + 1}/{total}.")
-            print(f'Description: {color("green")}{vote_descs[ind]}.{color}')
+            print(f'Description: {color("green")}{vote_descriptions[ind]}.{color}')
             print(calls_info_pretty_print(call))
             print("---------------------------")
 


### PR DESCRIPTION
Remove this output because it's not used during vote script runs anyway:

```
All known addresses extracted from a config file:
balancer_rewards_manager => 0x1dD909cDdF3dbe61aC08112dC0Fdf2Ab949f79D8
chain_network => mainnet
curve_rewards_manager_address => 0x753D5167C31fBEB5b49624314d74A957Eb271709
dai_token_address => 0x6b175474e89094c44da98b954eedeac495271d0f
finance_multisig_address => 0x48F300bD3C52c7dA6aAbDE4B683dEB27d38B9ABb
ldo_holder_address_for_tests => 0x9bb75183646e2a0dc855498bacd72b769ae6ced3
ldo_token_address => 0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32
ldo_vote_executors_for_tests => ['0x3e40d73eb977dc6a537af587d48316fee66e9c8c', '0xb8d83908aab38a159f3da47a59d84db8e1838712', '0xa2dfc431297aee387c05beef507e5335e684fbcd']
lido_dao_acl_address => 0x9895F0F17cc1d1891b6f18ee0b483B6f221b37Bb
lido_dao_agent_address => 0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c
lido_dao_composite_post_rebase_beacon_receiver => 0x55a7E1cbD678d9EbD50c7d69Dc75203B0dBdD431
lido_dao_deposit_security_module_address => 0xdb149235b6f40dc08810aa69869783be101790e7
lido_dao_execution_layer_rewards_vault => 0x388C818CA8B9251b393131C08a736A67ccB19297
...
```