### PR TITLE
Doc: strawman comments for votes

### DIFF
--- a/scripts/upgrade_shapella_1_goerli.py
+++ b/scripts/upgrade_shapella_1_goerli.py
@@ -1,18 +1,19 @@
 """
-TODO description
-Voting 23/03/2023.
+Voting 24/03/2023.
 
-Shapella Protocol Upgrade
+Lido V2 (Shapella-ready) protocol upgrade on Görli
 
-1. Publishing new implementation (0x47EbaB13B806773ec2A2d16873e2dF770D130b50) in Lido app APM repo
-2. Updating implementation of Lido app with the new one
-3. Publishing new implementation (0x5d39ABaa161e622B99D45616afC8B837E9F19a25) in Node Operators Registry app APM repo
-4. Updating implementation of Node Operators Registry app with the new one
-5. Publishing new implementation (0x1430194905301504e8830ce4B0b0df7187E84AbD) in Oracle app APM repo
-6. Updating implementation of Oracle app with new one
+1. Update `WithdwawalVault` proxy implementation
+2. Call `ShapellaUpgradeTemplate.startUpgrade()`
+3. Publish new `Lido` implementation in Lido app APM repo
+4. Update `Lido` implementation
+5. Publish new `NodeOperatorsRegistry` implementation in NodeOperatorsRegistry app APM repo
+6. Update `NodeOperatorsRegistry` implementation
+7. Publish new `LidoOracle` implementation in LidoOracle app APM repo
+8. Update `LidoOracle` implementation to `LegacyOracle`
+9. Create new role `STAKING_ROLE_ROLE` and assign to `StakingRouter`
+10. Call `ShapellaUpgradeTemplate.finishUpgrade()`
 
-# 7. Call Oracle's finalizeUpgrade_v3() to update internal version counter.
-# 8. Create permission for SET_EL_REWARDS_VAULT_ROLE of Lido app assigning it to Voting
 """
 
 import time
@@ -133,16 +134,16 @@ def start_vote(tx_params: Dict[str, str], silent: bool) -> Tuple[int, Optional[T
     ]
 
     vote_desc_items = [
-        "X) Update WithdrawalVault proxy implementation",
-        "X) TODO startUpgrade",
-        "1) Publish new implementation in Lido app APM repo",
-        "2) Updating implementation of Lido app",
-        "3) Publishing new implementation in Node Operators Registry app APM repo",
-        "4) Updating implementation of Node Operators Registry app",
-        "5) Publishing new implementation in Oracle app APM repo",
-        "6) Updating implementation of Oracle app",
-        "7) Create permission for STAKING_ROUTER_ROLE of NodeOperatorsRegistry assigning it to StakingRouter",
-        "8) Finalize upgrade by calling finalizeUpgrade() of ShapellaUpgradeTemplate",
+        "1) Update `WithdwawalVault` proxy implementation",
+        "2) Call `ShapellaUpgradeTemplate.startUpgrade()",
+        "3) Publish new implementation in Lido app APM repo",
+        "4) Updating implementation of Lido app",
+        "5) Publishing new implementation in Node Operators Registry app APM repo",
+        "6) Updating implementation of Node Operators Registry app",
+        "7) Publishing new implementation in Oracle app APM repo",
+        "8) Updating implementation of Oracle app",
+        "9) Create permission for STAKING_ROUTER_ROLE of NodeOperatorsRegistry assigning it to StakingRouter",
+        "10) Finalize upgrade by calling finalizeUpgrade() of ShapellaUpgradeTemplate",
     ]
 
     vote_items = bake_vote_items(vote_desc_items, call_script_items)

--- a/scripts/upgrade_shapella_2_revoke_roles_goerli.py
+++ b/scripts/upgrade_shapella_2_revoke_roles_goerli.py
@@ -1,8 +1,25 @@
 """
-TODO description
+
 Voting 23/03/2023.
 
-Shapella Protocol Upgrade - 2
+Lido V2 (Shapella-ready) protocol upgrade on Görli
+
+1. Call `ShapellaUpgradeTemplate.assertUpgradeIsFinishedCorrectly()`
+2. Revoke `MANAGE_FEE` role from `Voting`
+3. Revoke `MANAGE_WITHDRAWAL_KEY` role from `Voting`
+4. Revoke `MANAGE_PROTOCOL_CONTRACTS_ROLE` role from `Voting`
+5. Revoke `SET_EL_REWARDS_VAULT_ROLE` role from `Voting`
+6. Revoke `SET_EL_REWARDS_WITHDRAWAL_LIMIT_ROLE` role from `Voting`
+7. Revoke `ADD_NODE_OPERATOR_ROLE` role from `Voting`
+8. Revoke `SET_NODE_OPERATOR_ACTIVE_ROLE`
+9. Revoke `SET_NODE_OPERATOR_NAME_ROLE`
+10. Revoke `SET_NODE_OPERATOR_ADDRESS_ROLE`
+11. Revoke `REPORT_STOPPED_VALIDATORS_ROLE`
+12. Revoke `MANAGE_MEMBERS`
+13. Revoke `MANAGE_QUORUM`
+14. Revoke `SET_BEACON_SPEC`
+15. Revoke `SET_REPORT_BOUNDARIES`
+16. Revoke `SET_BEACON_REPORT_RECEIVER`
 
 """
 
@@ -64,22 +81,22 @@ def start_vote(tx_params: Dict[str, str], silent: bool) -> Tuple[int, Optional[T
     ]
 
     vote_desc_items = [
-        "X) Check protocol upgrade is finished",
-        "X) TODO revoke 1",
-        "X) TODO revoke 2",
-        "X) TODO revoke 3",
-        "X) TODO revoke 4",
-        "X) TODO revoke 5",
-        "X) TODO revoke 6",
-        "X) TODO revoke 7",
-        "X) TODO revoke 8",
-        "X) TODO revoke 9",
-        "X) TODO revoke 10",
-        "X) TODO revoke 11",
-        "X) TODO revoke 12",
-        "X) TODO revoke 13",
-        "X) TODO revoke 14",
-        "X) TODO revoke 15",
+        "1) Call `ShapellaUpgradeTemplate.assertUpgradeIsFinishedCorrectly()`",
+        "2) Revoke `MANAGE_FEE` role from `Voting`",
+        "3) Revoke `MANAGE_WITHDRAWAL_KEY` role from `Voting`",
+        "4) Revoke `MANAGE_PROTOCOL_CONTRACTS_ROLE` role from `Voting`",
+        "5) Revoke `SET_EL_REWARDS_VAULT_ROLE` role from `Voting`",
+        "6) Revoke `SET_EL_REWARDS_WITHDRAWAL_LIMIT_ROLE` role from `Voting`",
+        "7) Revoke `ADD_NODE_OPERATOR_ROLE` role from `Voting`",
+        "8) Revoke `SET_NODE_OPERATOR_ACTIVE_ROLE`",
+        "9) Revoke `SET_NODE_OPERATOR_NAME_ROLE`",
+        "10) Revoke `SET_NODE_OPERATOR_ADDRESS_ROLE`",
+        "11) Revoke `REPORT_STOPPED_VALIDATORS_ROLE`",
+        "12) Revoke `MANAGE_MEMBERS`",
+        "13) Revoke `MANAGE_QUORUM`",
+        "14) Revoke `SET_BEACON_SPEC`",
+        "15) Revoke `SET_REPORT_BOUNDARIES`",
+        "16) Revoke `SET_BEACON_REPORT_RECEIVER`",
     ]
 
     vote_items = bake_vote_items(vote_desc_items, call_script_items)

--- a/scripts/upgrade_shapella_2_revoke_roles_goerli.py
+++ b/scripts/upgrade_shapella_2_revoke_roles_goerli.py
@@ -1,6 +1,6 @@
 """
 
-Voting 23/03/2023.
+Voting 24/03/2023.
 
 Lido V2 (Shapella-ready) protocol upgrade on Görli
 
@@ -11,15 +11,15 @@ Lido V2 (Shapella-ready) protocol upgrade on Görli
 5. Revoke `SET_EL_REWARDS_VAULT_ROLE` role from `Voting`
 6. Revoke `SET_EL_REWARDS_WITHDRAWAL_LIMIT_ROLE` role from `Voting`
 7. Revoke `ADD_NODE_OPERATOR_ROLE` role from `Voting`
-8. Revoke `SET_NODE_OPERATOR_ACTIVE_ROLE`
-9. Revoke `SET_NODE_OPERATOR_NAME_ROLE`
-10. Revoke `SET_NODE_OPERATOR_ADDRESS_ROLE`
-11. Revoke `REPORT_STOPPED_VALIDATORS_ROLE`
-12. Revoke `MANAGE_MEMBERS`
-13. Revoke `MANAGE_QUORUM`
-14. Revoke `SET_BEACON_SPEC`
-15. Revoke `SET_REPORT_BOUNDARIES`
-16. Revoke `SET_BEACON_REPORT_RECEIVER`
+8. Revoke `SET_NODE_OPERATOR_ACTIVE_ROLE` role from `Voting`
+9. Revoke `SET_NODE_OPERATOR_NAME_ROLE` role from `Voting`
+10. Revoke `SET_NODE_OPERATOR_ADDRESS_ROLE` role from `Voting`
+11. Revoke `REPORT_STOPPED_VALIDATORS_ROLE` role from `Voting`
+12. Revoke `MANAGE_MEMBERS` role from `Voting`
+13. Revoke `MANAGE_QUORUM` role from `Voting`
+14. Revoke `SET_BEACON_SPEC` role from `Voting`
+15. Revoke `SET_REPORT_BOUNDARIES` role from `Voting`
+16. Revoke `SET_BEACON_REPORT_RECEIVER` role from `Voting`
 
 """
 
@@ -88,15 +88,15 @@ def start_vote(tx_params: Dict[str, str], silent: bool) -> Tuple[int, Optional[T
         "5) Revoke `SET_EL_REWARDS_VAULT_ROLE` role from `Voting`",
         "6) Revoke `SET_EL_REWARDS_WITHDRAWAL_LIMIT_ROLE` role from `Voting`",
         "7) Revoke `ADD_NODE_OPERATOR_ROLE` role from `Voting`",
-        "8) Revoke `SET_NODE_OPERATOR_ACTIVE_ROLE`",
-        "9) Revoke `SET_NODE_OPERATOR_NAME_ROLE`",
-        "10) Revoke `SET_NODE_OPERATOR_ADDRESS_ROLE`",
-        "11) Revoke `REPORT_STOPPED_VALIDATORS_ROLE`",
-        "12) Revoke `MANAGE_MEMBERS`",
-        "13) Revoke `MANAGE_QUORUM`",
-        "14) Revoke `SET_BEACON_SPEC`",
-        "15) Revoke `SET_REPORT_BOUNDARIES`",
-        "16) Revoke `SET_BEACON_REPORT_RECEIVER`",
+        "8) Revoke `SET_NODE_OPERATOR_ACTIVE_ROLE` role from `Voting",
+        "9) Revoke `SET_NODE_OPERATOR_NAME_ROLE` role from `Voting`",
+        "10) Revoke `SET_NODE_OPERATOR_ADDRESS_ROLE` role from `Voting`",
+        "11) Revoke `REPORT_STOPPED_VALIDATORS_ROLE` role from `Voting`",
+        "12) Revoke `MANAGE_MEMBERS` role from `Voting`",
+        "13) Revoke `MANAGE_QUORUM` role from `Voting`",
+        "14) Revoke `SET_BEACON_SPEC` role from `Voting`",
+        "15) Revoke `SET_REPORT_BOUNDARIES` role from `Voting`",
+        "16) Revoke `SET_BEACON_REPORT_RECEIVER` role from `Voting`",
     ]
 
     vote_items = bake_vote_items(vote_desc_items, call_script_items)

--- a/tests/test_upgrade_shapella_goerli.py
+++ b/tests/test_upgrade_shapella_goerli.py
@@ -1,5 +1,5 @@
 """
-Tests for voting ???
+Tests for voting 24/03/2023
 """
 from scripts.upgrade_shapella_1_goerli import start_vote
 from utils.test.tx_tracing_helpers import *


### PR DESCRIPTION
```
Voting 24/03/2023.

Lido V2 (Shapella-ready) protocol upgrade on Görli

1. Update `WithdwawalVault` proxy implementation
2. Call `ShapellaUpgradeTemplate.startUpgrade()`
3. Publish new `Lido` implementation in Lido app APM repo
4. Update `Lido` implementation
5. Publish new `NodeOperatorsRegistry` implementation in NodeOperatorsRegistry app APM repo
6. Update `NodeOperatorsRegistry` implementation
7. Publish new `LidoOracle` implementation in LidoOracle app APM repo
8. Update `LidoOracle` implementation to `LegacyOracle`
9. Create new role `STAKING_ROLE_ROLE` and assign to `StakingRouter`
10. Call `ShapellaUpgradeTemplate.finishUpgrade()`
```
and
```
Voting 24/03/2023.

Lido V2 (Shapella-ready) protocol upgrade on Görli

1. Call `ShapellaUpgradeTemplate.assertUpgradeIsFinishedCorrectly()`
2. Revoke `MANAGE_FEE` role from `Voting`
3. Revoke `MANAGE_WITHDRAWAL_KEY` role from `Voting`
4. Revoke `MANAGE_PROTOCOL_CONTRACTS_ROLE` role from `Voting`
5. Revoke `SET_EL_REWARDS_VAULT_ROLE` role from `Voting`
6. Revoke `SET_EL_REWARDS_WITHDRAWAL_LIMIT_ROLE` role from `Voting`
7. Revoke `ADD_NODE_OPERATOR_ROLE` role from `Voting`
8. Revoke `SET_NODE_OPERATOR_ACTIVE_ROLE` role from `Voting`
9. Revoke `SET_NODE_OPERATOR_NAME_ROLE` role from `Voting`
10. Revoke `SET_NODE_OPERATOR_ADDRESS_ROLE` role from `Voting`
11. Revoke `REPORT_STOPPED_VALIDATORS_ROLE` role from `Voting`
12. Revoke `MANAGE_MEMBERS` role from `Voting`
13. Revoke `MANAGE_QUORUM` role from `Voting`
14. Revoke `SET_BEACON_SPEC` role from `Voting`
15. Revoke `SET_REPORT_BOUNDARIES` role from `Voting`
16. Revoke `SET_BEACON_REPORT_RECEIVER` role from `Voting`
```
