### PR TITLE
vote_2023_04_25

### DIFF
--- a/scripts/vote_2023_04_25.py
+++ b/scripts/vote_2023_04_25.py
@@ -6,6 +6,8 @@ Voting 25/04/2023.
 3. Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'
 4. Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'
 5. Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690
+
+The vote REJECTED.
 """
 
 import time

--- a/scripts/vote_2023_04_25.py
+++ b/scripts/vote_2023_04_25.py
@@ -49,7 +49,7 @@ def start_vote(tx_params: Dict[str, str], silent: bool = False) -> Tuple[int, Op
 
     call_script_items = [
         # 1. Increase Easy Track motions amount limit: set motionsCountLimit to 20
-        set_motions_count_limit(motionsCountLimit)
+        set_motions_count_limit(motionsCountLimit),
         # 2. Change the on-chain name of node operator with id 1 from 'Certus One' to 'jumpcrypto'
         encode_set_node_operator_name(CertusOne_Jumpcrypto_id, CertusOne_Jumpcrypto_new_name, NO_registry),
         # 3. Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'
@@ -57,7 +57,7 @@ def start_vote(tx_params: Dict[str, str], silent: bool = False) -> Tuple[int, Op
         # 4. Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'
         encode_set_node_operator_name(SkillZ_Kiln_id, SkillZ_Kiln_new_name, NO_registry),
         # 5. Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690
-        encode_set_node_operator_reward_address(SkillZ_Kiln_id, SkillZ_Kiln_new_address, NO_registry),
+        encode_set_node_operator_reward_address(SkillZ_Kiln_id, SkillZ_Kiln_new_address, NO_registry)
     ]
 
     vote_desc_items = [

--- a/scripts/vote_2023_04_25.py
+++ b/scripts/vote_2023_04_25.py
@@ -1,11 +1,11 @@
 """
 Voting 25/04/2023.
 
-1. Change the on-chain name of node operator with id 1 from 'Certus One' to 'jumpcrypto'
-2. Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'
-3. Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'
-4. Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690
-5. Increase Easy Track motions amount limit: set motionsCountLimit to 20
+1. Increase Easy Track motions amount limit: set motionsCountLimit to 20
+2. Change the on-chain name of node operator with id 1 from 'Certus One' to 'jumpcrypto'
+3. Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'
+4. Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'
+5. Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690
 """
 
 import time
@@ -33,6 +33,8 @@ from utils.easy_track import (
 def start_vote(tx_params: Dict[str, str], silent: bool = False) -> Tuple[int, Optional[TransactionReceipt]]:
     """Prepare and run voting."""
 
+    motionsCountLimit = 20
+
     NO_registry = interface.NodeOperatorsRegistry(lido_dao_node_operators_registry)
 
     CertusOne_Jumpcrypto_id = 1
@@ -45,27 +47,25 @@ def start_vote(tx_params: Dict[str, str], silent: bool = False) -> Tuple[int, Op
     SkillZ_Kiln_new_name = "Kiln"
     SkillZ_Kiln_new_address = "0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690"
 
-    motionsCountLimit = 20
-
     call_script_items = [
-        # 1. Change the on-chain name of node operator with id 1 from 'Certus One' to 'jumpcrypto'
-        encode_set_node_operator_name(CertusOne_Jumpcrypto_id, CertusOne_Jumpcrypto_new_name, NO_registry),
-        # 2. Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'
-        encode_set_node_operator_name(ConsenSysCodefi_Consensys_id, ConsenSysCodefi_Consensys_new_name, NO_registry),
-        # 3. Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'
-        encode_set_node_operator_name(SkillZ_Kiln_id, SkillZ_Kiln_new_name, NO_registry),
-        # 4. Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690
-        encode_set_node_operator_reward_address(SkillZ_Kiln_id, SkillZ_Kiln_new_address, NO_registry),
-        #5. Increase Easy Track motions amount limit: set motionsCountLimit to 20
+        # 1. Increase Easy Track motions amount limit: set motionsCountLimit to 20
         set_motions_count_limit(motionsCountLimit)
+        # 2. Change the on-chain name of node operator with id 1 from 'Certus One' to 'jumpcrypto'
+        encode_set_node_operator_name(CertusOne_Jumpcrypto_id, CertusOne_Jumpcrypto_new_name, NO_registry),
+        # 3. Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'
+        encode_set_node_operator_name(ConsenSysCodefi_Consensys_id, ConsenSysCodefi_Consensys_new_name, NO_registry),
+        # 4. Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'
+        encode_set_node_operator_name(SkillZ_Kiln_id, SkillZ_Kiln_new_name, NO_registry),
+        # 5. Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690
+        encode_set_node_operator_reward_address(SkillZ_Kiln_id, SkillZ_Kiln_new_address, NO_registry),
     ]
 
     vote_desc_items = [
-        "1) Change the on-chain name of node operator with id 1 from 'Certus One' to 'jumpcrypto'",
-        "2) Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'",
-        "3) Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'",
-        "4) Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690",
-        "5) Increase Easy Track motions amount limit: set motionsCountLimit to 20",
+        "1) Increase Easy Track motions amount limit: set motionsCountLimit to 20",
+        "2) Change the on-chain name of node operator with id 1 from 'Certus One' to 'jumpcrypto'",
+        "3) Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'",
+        "4) Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'",
+        "5) Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690",
     ]
 
     vote_items = bake_vote_items(vote_desc_items, call_script_items)

--- a/scripts/vote_2023_04_25.py
+++ b/scripts/vote_2023_04_25.py
@@ -36,26 +36,26 @@ def start_vote(tx_params: Dict[str, str], silent: bool = False) -> Tuple[int, Op
     NO_registry = interface.NodeOperatorsRegistry(lido_dao_node_operators_registry)
 
     CertusOne_Jumpcrypto_id = 1
-    CertusOne_Jumpcrypto_name = "jumpcrypto"
+    CertusOne_Jumpcrypto_new_name = "jumpcrypto"
 
     ConsenSysCodefi_Consensys_id = 21
-    ConsenSysCodefi_Consensys_name = "Consensys"
+    ConsenSysCodefi_Consensys_new_name = "Consensys"
 
     SkillZ_Kiln_id = 8
-    SkillZ_Kiln_name = "Kiln"
-    SkillZ_Kiln_address = "0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690"
+    SkillZ_Kiln_new_name = "Kiln"
+    SkillZ_Kiln_new_address = "0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690"
 
     motionsCountLimit = 20
 
     call_script_items = [
         # 1. Change the on-chain name of node operator with id 1 from 'Certus One' to 'jumpcrypto'
-        encode_set_node_operator_name(CertusOne_Jumpcrypto_id, CertusOne_Jumpcrypto_name, NO_registry),
+        encode_set_node_operator_name(CertusOne_Jumpcrypto_id, CertusOne_Jumpcrypto_new_name, NO_registry),
         # 2. Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'
-        encode_set_node_operator_name(ConsenSysCodefi_Consensys_id, ConsenSysCodefi_Consensys_name, NO_registry),
+        encode_set_node_operator_name(ConsenSysCodefi_Consensys_id, ConsenSysCodefi_Consensys_new_name, NO_registry),
         # 3. Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'
-        encode_set_node_operator_name(SkillZ_Kiln_id, SkillZ_Kiln_name, NO_registry),
+        encode_set_node_operator_name(SkillZ_Kiln_id, SkillZ_Kiln_new_name, NO_registry),
         # 4. Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690
-        encode_set_node_operator_reward_address(SkillZ_Kiln_id, SkillZ_Kiln_address, NO_registry),
+        encode_set_node_operator_reward_address(SkillZ_Kiln_id, SkillZ_Kiln_new_address, NO_registry),
         #5. Increase Easy Track motions amount limit: set motionsCountLimit to 20
         set_motions_count_limit(motionsCountLimit)
     ]

--- a/scripts/vote_2023_04_25.py
+++ b/scripts/vote_2023_04_25.py
@@ -1,0 +1,81 @@
+"""
+Voting 25/04/2023.
+
+1. Change the on-chain name of node operator with id 1 from 'Certus One' to 'jumpcrypto'
+2. Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'
+3. Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'
+4. Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690
+5. Increase Easy Track motions amount limit: set motionsCountLimit to 20
+"""
+
+import time
+
+from typing import Dict, Tuple, Optional, List
+
+from brownie import interface
+from brownie.network.transaction import TransactionReceipt
+from utils.voting import bake_vote_items, confirm_vote_script, create_vote
+
+from utils.config import (
+    get_deployer_account,
+    lido_dao_node_operators_registry,
+)
+from utils.node_operators import (
+    encode_set_node_operator_name,
+    encode_set_node_operator_reward_address
+)
+
+from utils.easy_track import (
+    set_motions_count_limit
+)
+
+
+def start_vote(tx_params: Dict[str, str], silent: bool = False) -> Tuple[int, Optional[TransactionReceipt]]:
+    """Prepare and run voting."""
+
+    NO_registry = interface.NodeOperatorsRegistry(lido_dao_node_operators_registry)
+
+    CertusOne_Jumpcrypto_id = 1
+    CertusOne_Jumpcrypto_name = "jumpcrypto"
+
+    ConsenSysCodefi_Consensys_id = 21
+    ConsenSysCodefi_Consensys_name = "Consensys"
+
+    SkillZ_Kiln_id = 8
+    SkillZ_Kiln_name = "Kiln"
+    SkillZ_Kiln_address = "0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690"
+
+    motionsCountLimit = 20
+
+    call_script_items = [
+        # 1. Change the on-chain name of node operator with id 1 from 'Certus One' to 'jumpcrypto'
+        encode_set_node_operator_name(CertusOne_Jumpcrypto_id, CertusOne_Jumpcrypto_name, NO_registry),
+        # 2. Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'
+        encode_set_node_operator_name(ConsenSysCodefi_Consensys_id, ConsenSysCodefi_Consensys_name, NO_registry),
+        # 3. Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'
+        encode_set_node_operator_name(SkillZ_Kiln_id, SkillZ_Kiln_name, NO_registry),
+        # 4. Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690
+        encode_set_node_operator_reward_address(SkillZ_Kiln_id, SkillZ_Kiln_address, NO_registry),
+        #5. Increase Easy Track motions amount limit: set motionsCountLimit to 20
+        set_motions_count_limit(motionsCountLimit)
+    ]
+
+    vote_desc_items = [
+        "1) Change the on-chain name of node operator with id 1 from 'Certus One' to 'jumpcrypto'",
+        "2) Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'",
+        "3) Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'",
+        "4) Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690",
+        "5) Increase Easy Track motions amount limit: set motionsCountLimit to 20",
+    ]
+
+    vote_items = bake_vote_items(vote_desc_items, call_script_items)
+
+    return confirm_vote_script(vote_items, silent) and create_vote(vote_items, tx_params)
+
+
+def main():
+    vote_id, _ = start_vote({"from": get_deployer_account(), "priority_fee": "4 gwei"})
+
+    vote_id >= 0 and print(f"Vote created: {vote_id}.")
+
+    time.sleep(5)  # hack for waiting thread #2.

--- a/tests/test_2023_04_25.py
+++ b/tests/test_2023_04_25.py
@@ -46,18 +46,25 @@ def test_vote(
     motionsCountLimit_before = 12
     motionsCountLimit_after = 20
 
+    # NO's data indexes
+    active_index = 0
+    name_index = 1
+    rewardAddress_index = 2
+    stakingLimit_index = 3
+    stoppedValidators_index = 4
+
     # get NO's data before
     CertusOne_Jumpcrypto_data_before = node_operators_registry.getNodeOperator(CertusOne_Jumpcrypto_id, True)
     ConsenSysCodefi_Consensys_data_before = node_operators_registry.getNodeOperator(ConsenSysCodefi_Consensys_id, True)
     SkillZ_Kiln_data_before = node_operators_registry.getNodeOperator(SkillZ_Kiln_id, True)
 
     # check names before
-    assert CertusOne_Jumpcrypto_data_before[1] == CertusOne_Jumpcrypto_name_before, "Incorrect NO#1 name before"
-    assert ConsenSysCodefi_Consensys_data_before[1] == ConsenSysCodefi_Consensys_name_before, "Incorrect NO#21 name before"
-    assert SkillZ_Kiln_data_before[1] == SkillZ_Kiln_name_before, "Incorrect NO#8 name before"
+    assert CertusOne_Jumpcrypto_data_before[name_index] == CertusOne_Jumpcrypto_name_before, "Incorrect NO#1 name before"
+    assert ConsenSysCodefi_Consensys_data_before[name_index] == ConsenSysCodefi_Consensys_name_before, "Incorrect NO#21 name before"
+    assert SkillZ_Kiln_data_before[name_index] == SkillZ_Kiln_name_before, "Incorrect NO#8 name before"
 
     # check SkillZ_Kiln reward address before
-    assert SkillZ_Kiln_data_before[2] == SkillZ_Kiln_address_before, "Incorrect NO#8 reward address before"
+    assert SkillZ_Kiln_data_before[rewardAddress_index] == SkillZ_Kiln_address_before, "Incorrect NO#8 reward address before"
 
     # check Easy Track motions count limit before
     easy_track.motionsCountLimit() == motionsCountLimit_before, "Incorrect motions count limit before"
@@ -77,25 +84,25 @@ def test_vote(
     SkillZ_Kiln_data_after = node_operators_registry.getNodeOperator(SkillZ_Kiln_id, True)
 
     # compare NO#1 (CertusOne -> Jumpcrypto) data before and after
-    assert CertusOne_Jumpcrypto_data_before[0] == CertusOne_Jumpcrypto_data_after[0] # active
-    assert CertusOne_Jumpcrypto_name_after == CertusOne_Jumpcrypto_data_after[1] # name
-    assert CertusOne_Jumpcrypto_data_before[2] == CertusOne_Jumpcrypto_data_after[2] # rewardAddress
-    assert CertusOne_Jumpcrypto_data_before[3] == CertusOne_Jumpcrypto_data_after[3] # stakingLimit
-    assert CertusOne_Jumpcrypto_data_before[4] == CertusOne_Jumpcrypto_data_after[4] # stoppedValidators
+    assert CertusOne_Jumpcrypto_data_before[active_index] == CertusOne_Jumpcrypto_data_after[active_index] # active
+    assert CertusOne_Jumpcrypto_name_after == CertusOne_Jumpcrypto_data_after[name_index] # name
+    assert CertusOne_Jumpcrypto_data_before[rewardAddress_index] == CertusOne_Jumpcrypto_data_after[rewardAddress_index] # rewardAddress
+    assert CertusOne_Jumpcrypto_data_before[stakingLimit_index] == CertusOne_Jumpcrypto_data_after[stakingLimit_index] # stakingLimit
+    assert CertusOne_Jumpcrypto_data_before[stoppedValidators_index] == CertusOne_Jumpcrypto_data_after[stoppedValidators_index] # stoppedValidators
 
     # compare NO#21 (ConsenSysCodefi -> Consensys) data before and after
-    assert ConsenSysCodefi_Consensys_data_before[0] == ConsenSysCodefi_Consensys_data_after[0] # active
-    assert ConsenSysCodefi_Consensys_name_after == ConsenSysCodefi_Consensys_data_after[1] # name
-    assert ConsenSysCodefi_Consensys_data_before[2] == ConsenSysCodefi_Consensys_data_after[2] # rewardAddress
-    assert ConsenSysCodefi_Consensys_data_before[3] == ConsenSysCodefi_Consensys_data_after[3] # stakingLimit
-    assert ConsenSysCodefi_Consensys_data_before[4] == ConsenSysCodefi_Consensys_data_after[4] # stoppedValidators
+    assert ConsenSysCodefi_Consensys_data_before[active_index] == ConsenSysCodefi_Consensys_data_after[active_index] # active
+    assert ConsenSysCodefi_Consensys_name_after == ConsenSysCodefi_Consensys_data_after[name_index] # name
+    assert ConsenSysCodefi_Consensys_data_before[rewardAddress_index] == ConsenSysCodefi_Consensys_data_after[rewardAddress_index] # rewardAddress
+    assert ConsenSysCodefi_Consensys_data_before[stakingLimit_index] == ConsenSysCodefi_Consensys_data_after[stakingLimit_index] # stakingLimit
+    assert ConsenSysCodefi_Consensys_data_before[stoppedValidators_index] == ConsenSysCodefi_Consensys_data_after[stoppedValidators_index] # stoppedValidators
 
     # compare NO#8 (ConsenSysCodefi -> Consensys) data before and after
-    assert SkillZ_Kiln_data_before[0] == SkillZ_Kiln_data_after[0] # active
-    assert SkillZ_Kiln_name_after == SkillZ_Kiln_data_after[1] # name
-    assert SkillZ_Kiln_address_after == SkillZ_Kiln_data_after[2] # rewardAddress
-    assert SkillZ_Kiln_data_before[3] == SkillZ_Kiln_data_after[3] # stakingLimit
-    assert SkillZ_Kiln_data_before[4] == SkillZ_Kiln_data_after[4] # stoppedValidators
+    assert SkillZ_Kiln_data_before[active_index] == SkillZ_Kiln_data_after[active_index] # active
+    assert SkillZ_Kiln_name_after == SkillZ_Kiln_data_after[name_index] # name
+    assert SkillZ_Kiln_address_after == SkillZ_Kiln_data_after[rewardAddress_index] # rewardAddress
+    assert SkillZ_Kiln_data_before[stakingLimit_index] == SkillZ_Kiln_data_after[stakingLimit_index] # stakingLimit
+    assert SkillZ_Kiln_data_before[stoppedValidators_index] == SkillZ_Kiln_data_after[stoppedValidators_index] # stoppedValidators
 
     # check Easy Track motions count limit after
     easy_track.motionsCountLimit() == motionsCountLimit_after, "Incorrect motions count limit after"

--- a/tests/test_2023_04_25.py
+++ b/tests/test_2023_04_25.py
@@ -1,0 +1,145 @@
+"""
+Tests for voting 25/04/2023.
+
+"""
+from scripts.vote_2023_04_25 import start_vote
+
+from brownie.network.transaction import TransactionReceipt
+
+from utils.config import network_name
+from utils.test.tx_tracing_helpers import *
+from utils.test.event_validators.node_operators_registry import (
+    validate_node_operator_name_set_event,
+    validate_node_operator_reward_address_set_event,
+    NodeOperatorNameSetItem,
+    NodeOperatorRewardAddressSetItem,
+)
+from utils.test.event_validators.easy_track import (
+    validate_motions_count_limit_changed_event
+)
+
+def test_vote(
+    helpers,
+    accounts,
+    vote_id_from_env,
+    bypass_events_decoding,
+    ldo_holder,
+    dao_voting,
+    node_operators_registry,
+    easy_track
+):
+
+    CertusOne_Jumpcrypto_id = 1
+    CertusOne_Jumpcrypto_name_before = "Certus One"
+    CertusOne_Jumpcrypto_name_after = "jumpcrypto"
+
+    ConsenSysCodefi_Consensys_id = 21
+    ConsenSysCodefi_Consensys_name_before = "ConsenSys Codefi"
+    ConsenSysCodefi_Consensys_name_after = "Consensys"
+
+    SkillZ_Kiln_id = 8
+    SkillZ_Kiln_name_before = "SkillZ"
+    SkillZ_Kiln_name_after = "Kiln"
+    SkillZ_Kiln_address_before = "0xe080E860741b7f9e8369b61645E68AD197B1e74C"
+    SkillZ_Kiln_address_after = "0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690"
+
+    motionsCountLimit_before = 12
+    motionsCountLimit_after = 20
+
+    # get NO's data before
+    CertusOne_Jumpcrypto_data_before = node_operators_registry.getNodeOperator(CertusOne_Jumpcrypto_id, True)
+    ConsenSysCodefi_Consensys_data_before = node_operators_registry.getNodeOperator(ConsenSysCodefi_Consensys_id, True)
+    SkillZ_Kiln_data_before = node_operators_registry.getNodeOperator(SkillZ_Kiln_id, True)
+
+    # check names before
+    assert CertusOne_Jumpcrypto_data_before[1] == CertusOne_Jumpcrypto_name_before, "Incorrect NO#1 name before"
+    assert ConsenSysCodefi_Consensys_data_before[1] == ConsenSysCodefi_Consensys_name_before, "Incorrect NO#21 name before"
+    assert SkillZ_Kiln_data_before[1] == SkillZ_Kiln_name_before, "Incorrect NO#8 name before"
+
+    # check SkillZ_Kiln reward address before
+    assert SkillZ_Kiln_data_before[2] == SkillZ_Kiln_address_before, "Incorrect NO#8 reward address before"
+
+    # check Easy Track motions count limit before
+    easy_track.motionsCountLimit() == motionsCountLimit_before, "Incorrect motions count limit before"
+
+    ##
+    ## START VOTE
+    ##
+    vote_id = vote_id_from_env or start_vote({"from": ldo_holder}, silent=True)[0]
+
+    tx: TransactionReceipt = helpers.execute_vote(
+        vote_id=vote_id, accounts=accounts, dao_voting=dao_voting, skip_time=3 * 60 * 60 * 24
+    )
+
+    # get NO's data before
+    CertusOne_Jumpcrypto_data_after = node_operators_registry.getNodeOperator(CertusOne_Jumpcrypto_id, True)
+    ConsenSysCodefi_Consensys_data_after = node_operators_registry.getNodeOperator(ConsenSysCodefi_Consensys_id, True)
+    SkillZ_Kiln_data_after = node_operators_registry.getNodeOperator(SkillZ_Kiln_id, True)
+
+    # compare NO#1 (CertusOne -> Jumpcrypto) data before and after
+    assert CertusOne_Jumpcrypto_data_before[0] == CertusOne_Jumpcrypto_data_after[0] # active
+    assert CertusOne_Jumpcrypto_name_after == CertusOne_Jumpcrypto_data_after[1] # name
+    assert CertusOne_Jumpcrypto_data_before[2] == CertusOne_Jumpcrypto_data_after[2] # rewardAddress
+    assert CertusOne_Jumpcrypto_data_before[3] == CertusOne_Jumpcrypto_data_after[3] # stakingLimit
+    assert CertusOne_Jumpcrypto_data_before[4] == CertusOne_Jumpcrypto_data_after[4] # stoppedValidators
+
+    # compare NO#21 (ConsenSysCodefi -> Consensys) data before and after
+    assert ConsenSysCodefi_Consensys_data_before[0] == ConsenSysCodefi_Consensys_data_after[0] # active
+    assert ConsenSysCodefi_Consensys_name_after == ConsenSysCodefi_Consensys_data_after[1] # name
+    assert ConsenSysCodefi_Consensys_data_before[2] == ConsenSysCodefi_Consensys_data_after[2] # rewardAddress
+    assert ConsenSysCodefi_Consensys_data_before[3] == ConsenSysCodefi_Consensys_data_after[3] # stakingLimit
+    assert ConsenSysCodefi_Consensys_data_before[4] == ConsenSysCodefi_Consensys_data_after[4] # stoppedValidators
+
+    # compare NO#8 (ConsenSysCodefi -> Consensys) data before and after
+    assert SkillZ_Kiln_data_before[0] == SkillZ_Kiln_data_after[0] # active
+    assert SkillZ_Kiln_name_after == SkillZ_Kiln_data_after[1] # name
+    assert SkillZ_Kiln_address_after == SkillZ_Kiln_data_after[2] # rewardAddress
+    assert SkillZ_Kiln_data_before[3] == SkillZ_Kiln_data_after[3] # stakingLimit
+    assert SkillZ_Kiln_data_before[4] == SkillZ_Kiln_data_after[4] # stoppedValidators
+
+    # check Easy Track motions count limit after
+    easy_track.motionsCountLimit() == motionsCountLimit_after, "Incorrect motions count limit after"
+
+    # validate vote events
+    assert count_vote_items_by_events(tx, dao_voting) == 5, "Incorrect voting items count"
+
+    display_voting_events(tx)
+
+    if bypass_events_decoding or network_name() in ("goerli", "goerli-fork"):
+        return
+
+    evs = group_voting_events(tx)
+
+
+    validate_node_operator_name_set_event(
+        evs[0],
+        NodeOperatorNameSetItem(
+            id=1,
+            name=CertusOne_Jumpcrypto_name_after
+        )
+    )
+    validate_node_operator_name_set_event(
+        evs[1],
+        NodeOperatorNameSetItem(
+            id=21,
+            name=ConsenSysCodefi_Consensys_name_after
+        )
+    )
+    validate_node_operator_name_set_event(
+        evs[2],
+        NodeOperatorNameSetItem(
+            id=8,
+            name=SkillZ_Kiln_name_after
+        )
+    )
+    validate_node_operator_reward_address_set_event(
+        evs[3],
+        NodeOperatorRewardAddressSetItem(
+            id=8,
+            reward_address=SkillZ_Kiln_address_after
+        )
+    )
+    validate_motions_count_limit_changed_event(
+        evs[4],
+        motionsCountLimit_after
+    )

--- a/tests/test_2023_04_25.py
+++ b/tests/test_2023_04_25.py
@@ -97,7 +97,7 @@ def test_vote(
     assert ConsenSysCodefi_Consensys_data_before[stakingLimit_index] == ConsenSysCodefi_Consensys_data_after[stakingLimit_index] # stakingLimit
     assert ConsenSysCodefi_Consensys_data_before[stoppedValidators_index] == ConsenSysCodefi_Consensys_data_after[stoppedValidators_index] # stoppedValidators
 
-    # compare NO#8 (ConsenSysCodefi -> Consensys) data before and after
+    # compare NO#8 (SkillZ -> Kiln) data before and after
     assert SkillZ_Kiln_data_before[active_index] == SkillZ_Kiln_data_after[active_index] # active
     assert SkillZ_Kiln_name_after == SkillZ_Kiln_data_after[name_index] # name
     assert SkillZ_Kiln_address_after == SkillZ_Kiln_data_after[rewardAddress_index] # rewardAddress

--- a/tests/test_2023_04_25.py
+++ b/tests/test_2023_04_25.py
@@ -118,35 +118,35 @@ def test_vote(
     evs = group_voting_events(tx)
 
 
-    validate_node_operator_name_set_event(
+    validate_motions_count_limit_changed_event(
         evs[0],
+        motionsCountLimit_after
+    )
+    validate_node_operator_name_set_event(
+        evs[1],
         NodeOperatorNameSetItem(
             id=1,
             name=CertusOne_Jumpcrypto_name_after
         )
     )
     validate_node_operator_name_set_event(
-        evs[1],
+        evs[2],
         NodeOperatorNameSetItem(
             id=21,
             name=ConsenSysCodefi_Consensys_name_after
         )
     )
     validate_node_operator_name_set_event(
-        evs[2],
+        evs[3],
         NodeOperatorNameSetItem(
             id=8,
             name=SkillZ_Kiln_name_after
         )
     )
     validate_node_operator_reward_address_set_event(
-        evs[3],
+        evs[4],
         NodeOperatorRewardAddressSetItem(
             id=8,
             reward_address=SkillZ_Kiln_address_after
         )
-    )
-    validate_motions_count_limit_changed_event(
-        evs[4],
-        motionsCountLimit_after
     )

--- a/utils/easy_track.py
+++ b/utils/easy_track.py
@@ -29,3 +29,12 @@ def remove_evmscript_factory(factory: Contract) -> Tuple[str, str]:
 
 def create_permissions(contract: Contract, method: str) -> str:
     return contract.address + getattr(contract, method).signature[2:]
+
+
+def set_motions_count_limit(motionsCountLimit: int) -> Tuple[str, str]:
+    easy_track = contracts.easy_track
+
+    return (
+        easy_track.address,
+        easy_track.setMotionsCountLimit.encode_input(motionsCountLimit)
+    )

--- a/utils/node_operators.py
+++ b/utils/node_operators.py
@@ -19,6 +19,20 @@ def encode_set_node_operators_staking_limits_evm_script(node_operators, registry
     ])
 
 
+def encode_set_node_operator_name(id, name, registry):
+    return (
+        registry.address,
+        registry.setNodeOperatorName.encode_input(id, name)
+    )
+
+
+def encode_set_node_operator_reward_address(id, rewardAddress, registry):
+    return (
+        registry.address,
+        registry.setNodeOperatorRewardAddress.encode_input(id, rewardAddress)
+    )
+
+
 def get_node_operators(registry):
     return [{**registry.getNodeOperator(i, True), **{'index': i}} for i in range(registry.getNodeOperatorsCount())]
 

--- a/utils/test/event_validators/easy_track.py
+++ b/utils/test/event_validators/easy_track.py
@@ -28,3 +28,13 @@ def validate_evmscript_factory_removed_event(event: EventDict, factory_addr: str
     assert event.count("EVMScriptFactoryRemoved") == 1
 
     assert event["EVMScriptFactoryRemoved"]["_evmScriptFactory"] == factory_addr
+
+
+def validate_motions_count_limit_changed_event(event: EventDict, motions_count_limit: int):
+    _events_chain = ["LogScriptCall", "MotionsCountLimitChanged"]
+
+    validate_events_chain([e.name for e in event], _events_chain)
+
+    assert event.count("MotionsCountLimitChanged") == 1
+
+    assert event["MotionsCountLimitChanged"]["_newMotionsCountLimit"] == motions_count_limit

--- a/utils/test/event_validators/node_operators_registry.py
+++ b/utils/test/event_validators/node_operators_registry.py
@@ -10,9 +10,17 @@ class NodeOperatorItem(NamedTuple):
     reward_address: str
     staking_limit: int
 
-class NodeOperatorStakingLimitSetItem(NamedTuple):    
+class NodeOperatorStakingLimitSetItem(NamedTuple):
     id: int
     staking_limit: int
+
+class NodeOperatorNameSetItem(NamedTuple):
+    id: int
+    name: str
+
+class NodeOperatorRewardAddressSetItem(NamedTuple):
+    id: int
+    reward_address: str
 
 
 def validate_node_operator_added_event(
@@ -43,4 +51,29 @@ def validate_node_operator_staking_limit_set_event(
     assert event.count("NodeOperatorStakingLimitSet") == 1
 
     assert event["NodeOperatorStakingLimitSet"]["id"] == node_operator_staking_limit_item.id
-    assert event["NodeOperatorStakingLimitSet"]["stakingLimit"] == node_operator_staking_limit_item.staking_limit   
+    assert event["NodeOperatorStakingLimitSet"]["stakingLimit"] == node_operator_staking_limit_item.staking_limit
+
+
+def validate_node_operator_name_set_event(
+    event: EventDict, node_operator_name_item: NodeOperatorNameSetItem
+):
+    _events_chain = ["LogScriptCall", "KeysOpIndexSet", "NodeOperatorNameSet"]
+
+    validate_events_chain([e.name for e in event], _events_chain)
+
+    assert event.count("NodeOperatorNameSet") == 1
+
+    assert event["NodeOperatorNameSet"]["id"] == node_operator_name_item.id
+    assert event["NodeOperatorNameSet"]["name"] == node_operator_name_item.name
+
+def validate_node_operator_reward_address_set_event(
+    event: EventDict, node_operator_reward_address_item: NodeOperatorRewardAddressSetItem
+):
+    _events_chain = ["LogScriptCall", "KeysOpIndexSet", "NodeOperatorRewardAddressSet"]
+
+    validate_events_chain([e.name for e in event], _events_chain)
+
+    assert event.count("NodeOperatorRewardAddressSet") == 1
+
+    assert event["NodeOperatorRewardAddressSet"]["id"] == node_operator_reward_address_item.id
+    assert event["NodeOperatorRewardAddressSet"]["rewardAddress"] == node_operator_reward_address_item.reward_address


### PR DESCRIPTION
Voting 25/04/2023.

1. Increase Easy Track motions amount limit: set motionsCountLimit to 20
2. Change the on-chain name of node operator with id 1 from 'Certus One' to 'jumpcrypto'
3. Change the on-chain name of node operator with id 21 from 'ConsenSys Codefi' to 'Consensys'
4. Change the on-chain name of node operator with id 8 from 'SkillZ' to 'Kiln'
5. Change the reward address of node operator with id 8 from 0xe080E860741b7f9e8369b61645E68AD197B1e74C to 0xD6B7d52E15678B9195F12F3a6D6cb79dcDcCb690