### PR TITLE
Add anvil RPC node support

### DIFF
--- a/archive/tests/shapella_upgrade_acceptance/test_accounting_oracle_negative.py
+++ b/archive/tests/shapella_upgrade_acceptance/test_accounting_oracle_negative.py
@@ -402,11 +402,25 @@ class TestSubmitReportExtraDataList:
         ):
             self.report(extra_data, items_count=1)
 
-    def test_invalid_extra_data_sort_order(self):
+    def test_invalid_extra_data_sort_order(self, node_operators_registry):
+        node_operator_id = 1
+        summary = node_operators_registry.getNodeOperatorSummary(node_operator_id)
         extra_data = b"".join(
             (
-                build_extra_data_item(0, ItemType.EXTRA_DATA_TYPE_STUCK_VALIDATORS, 1, [1], [1]),
-                build_extra_data_item(1, ItemType.EXTRA_DATA_TYPE_STUCK_VALIDATORS, 1, [1], [1]),
+                build_extra_data_item(
+                    0,
+                    ItemType.EXTRA_DATA_TYPE_STUCK_VALIDATORS,
+                    1,
+                    [node_operator_id],
+                    [summary["totalExitedValidators"]],
+                ),
+                build_extra_data_item(
+                    1,
+                    ItemType.EXTRA_DATA_TYPE_STUCK_VALIDATORS,
+                    1,
+                    [node_operator_id],
+                    [summary["totalExitedValidators"]],
+                ),
             )
         )
 

--- a/tests/acceptance/test_accounting_oracle_negative.py
+++ b/tests/acceptance/test_accounting_oracle_negative.py
@@ -263,10 +263,24 @@ class TestSubmitReportExtraDataList:
             self.report(extra_data, items_count=1)
 
     def test_invalid_extra_data_sort_order(self):
+        node_operator_id = 1
+        summary = contracts.node_operators_registry.getNodeOperatorSummary(node_operator_id)
         extra_data = b"".join(
             (
-                build_extra_data_item(0, ItemType.EXTRA_DATA_TYPE_STUCK_VALIDATORS, 1, [1], [1]),
-                build_extra_data_item(1, ItemType.EXTRA_DATA_TYPE_STUCK_VALIDATORS, 1, [1], [1]),
+                build_extra_data_item(
+                    0,
+                    ItemType.EXTRA_DATA_TYPE_STUCK_VALIDATORS,
+                    1,
+                    [node_operator_id],
+                    [summary["stuckValidatorsCount"]],
+                ),
+                build_extra_data_item(
+                    1,
+                    ItemType.EXTRA_DATA_TYPE_STUCK_VALIDATORS,
+                    1,
+                    [node_operator_id],
+                    [summary["stuckValidatorsCount"]],
+                ),
             )
         )
 
@@ -280,8 +294,20 @@ class TestSubmitReportExtraDataList:
 
         extra_data = b"".join(
             (
-                build_extra_data_item(0, ItemType.EXTRA_DATA_TYPE_EXITED_VALIDATORS, 1, [1], [1]),
-                build_extra_data_item(1, ItemType.EXTRA_DATA_TYPE_EXITED_VALIDATORS, 1, [1], [1]),
+                build_extra_data_item(
+                    0,
+                    ItemType.EXTRA_DATA_TYPE_EXITED_VALIDATORS,
+                    1,
+                    [node_operator_id],
+                    [summary["totalExitedValidators"]],
+                ),
+                build_extra_data_item(
+                    1,
+                    ItemType.EXTRA_DATA_TYPE_EXITED_VALIDATORS,
+                    1,
+                    [node_operator_id],
+                    [summary["totalExitedValidators"]],
+                ),
             )
         )
 
@@ -294,9 +320,11 @@ class TestSubmitReportExtraDataList:
             self.report(extra_data)
 
     def test_unexpected_extra_data_item(self, extra_data_service: ExtraDataService) -> None:
+        node_operator_id = 1
+        summary = contracts.node_operators_registry.getNodeOperatorSummary(node_operator_id)
         extra_data = extra_data_service.collect(
-            {(1, 1): 1},
-            {(1, 1): 1},
+            {(1, node_operator_id): summary["stuckValidatorsCount"]},
+            {(1, node_operator_id): summary["totalExitedValidators"]},
             MAX_ACCOUNTING_EXTRA_DATA_LIST_ITEMS_COUNT,
             1,
         )
@@ -321,9 +349,11 @@ class TestSubmitReportExtraDataList:
         consensus_member: Account,
         extra_data_service: ExtraDataService,
     ):
+        node_operator_id = 1
+        summary = contracts.node_operators_registry.getNodeOperatorSummary(node_operator_id)
         extra_data = extra_data_service.collect(
-            {(1, 1): 1},
-            {(1, 1): 1},
+            {(1, node_operator_id): summary["stuckValidatorsCount"]},
+            {(1, node_operator_id): summary["totalExitedValidators"]},
             MAX_ACCOUNTING_EXTRA_DATA_LIST_ITEMS_COUNT,
             1,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ def deployer():
 def steth_holder(accounts):
     steth_holder = accounts.at("0x176F3DAb24a159341c0509bB36B833E7fdd0a131", force=True)
     web3.provider.make_request("evm_setAccountBalance", [steth_holder.address, "0x152D02C7E14AF6800000"])
+    web3.provider.make_request("anvil_setBalance", [steth_holder.address, "0x152D02C7E14AF6800000"])
     steth_holder.transfer(contracts.lido, ETH(10000))
     return steth_holder
 
@@ -49,6 +50,7 @@ def ldo_holder(accounts):
 def stranger(accounts):
     stranger = accounts.at("0x98eC059dC3aDFbdd63429454aeB0C990fbA4a124", force=True)
     web3.provider.make_request("evm_setAccountBalance", [stranger.address, "0x152D02C7E14AF6800000"])
+    web3.provider.make_request("anvil_setBalance", [stranger.address, "0x152D02C7E14AF6800000"])
     assert stranger.balance() == ETH(100000)
     return stranger
 
@@ -149,6 +151,8 @@ class Helpers:
             Contract.from_explorer(VALIDATORS_EXIT_BUS_ORACLE)
             Contract.from_explorer(WITHDRAWAL_QUEUE)
             Contract.from_explorer(STAKING_ROUTER)
+            Contract.from_explorer(LIDO)
+            Contract.from_explorer(NODE_OPERATORS_REGISTRY)
 
             Helpers._etherscan_is_fetched = True
 


### PR DESCRIPTION
Currently, only acceptance tests might be run with the anvil node.
How to run tests:
1. Spawn anvil node in one tab: `anvil --fork-url=https://mainnet.infura.io/v3/YOUR_INFURA_KEY --base-fee 0 --auto-impersonate --steps-tracing --mnemonic "test test test test test test test test test test test junk"`
2. Run acceptance tests in another tab: `brownie test ./tests/acceptance --network mainnet-fork`

The question is how faster is the `anvil` node over the `ganache`. My results are very strange:
- anvil: 45.38s user 2.55s system 8% cpu 9:37.67 total
- ganache: 35.79s user 1.96s system 20% cpu 3:08.60 total

The ganache node is almost 3 times faster.