### PR TITLE
fix: tune-up tests after the vote #180

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ from utils.config import contracts, network_name, MAINNET_VOTE_DURATION
 from utils.config import *
 from utils.txs.deploy import deploy_from_prepared_tx
 from utils.test.helpers import ETH
-from utils.balance import set_balance
+from utils.balance import set_balance, set_balance_in_wei
 from functools import wraps
 
 ENV_OMNIBUS_BYPASS_EVENTS_DECODING = "OMNIBUS_BYPASS_EVENTS_DECODING"
@@ -27,9 +27,11 @@ ENV_OMNIBUS_VOTE_IDS = "OMNIBUS_VOTE_IDS"
 def shared_setup(fn_isolation):
     pass
 
+
 @pytest.fixture(scope="session", autouse=True)
 def network_gas_price():
     network.gas_price("2 gwei")
+
 
 @pytest.fixture(scope="function")
 def deployer():
@@ -63,9 +65,11 @@ def delegate1():
 def delegate2():
     return set_balance("0x100b896F2Dd8c4Ca619db86BCDDb7E085143C1C5", 100000)
 
+
 @pytest.fixture(scope="module")
 def trp_recipient(accounts):
     return set_balance("0x228cCaFeA1fa21B74257Af975A9D84d87188c61B", 100000)
+
 
 @pytest.fixture(scope="module")
 def eth_whale(accounts):
@@ -253,24 +257,36 @@ def parse_events_from_local_abi():
             # Added contract will resolve from address during state._find_contract without a request to Etherscan
             state._add_contract(contract)
 
+
 @pytest.fixture(scope="session", autouse=True)
 def add_balance_check_middleware():
-    web3.middleware_onion.add(balance_check_middleware, name='balance_check')
+    web3.middleware_onion.add(balance_check_middleware, name="balance_check")
+
 
 # TODO: Such implicit manipulation of the balances may lead to hard-debugging errors in the future.
-# Better to return back balance after request is done.
-def ensure_balance(address):
-    if web3.eth.get_balance(address) < ETH(999):
-        set_balance(address, 1000000)
+def ensure_balance(address) -> int:
+    old_balance = web3.eth.get_balance(address)
+    if old_balance < ETH(999):
+        set_balance_in_wei(address, ETH(1000000))
+    return web3.eth.get_balance(address) - old_balance
+
 
 def balance_check_middleware(make_request, web3):
     @wraps(make_request)
     def middleware(method, params):
+        from_address = None
+        balance_diff = 0
         if method in ["eth_sendTransaction", "eth_sendRawTransaction"]:
             transaction = params[0]
-            from_address = transaction.get('from')
+            from_address = transaction.get("from")
             if from_address:
-                ensure_balance(from_address)
+                balance_diff = ensure_balance(from_address)
 
-        return make_request(method, params)
+        result = make_request(method, params)
+        if balance_diff > 0:
+            new_balance = max(0, web3.eth.get_balance(from_address) - balance_diff)
+            set_balance_in_wei(from_address, new_balance)
+
+        return result
+
     return middleware

--- a/tests/regression/test_neg_rebase_sanity_checks.py
+++ b/tests/regression/test_neg_rebase_sanity_checks.py
@@ -16,6 +16,7 @@ INITIAL_SLASHING_AMOUNT_PWEI = 1000
 INACTIVITY_PENALTIES_AMOUNT_PWEI = 101
 ONE_PWEI = ETH(0.001)
 
+
 @pytest.fixture(scope="module")
 def oracle_report_sanity_checker() -> Contract:
     return contracts.oracle_report_sanity_checker
@@ -28,14 +29,18 @@ def test_negative_rebase_correct_exited_validators_count_pos_rebase(oracle_repor
     reported_validators = exited_validators_count()
 
     reported_validators_values = [value + 2 for value in reported_validators.values()]
-    oracle_report(cl_diff=ETH(300), stakingModuleIdsWithNewlyExitedValidators=list(reported_validators.keys()),
-                   numExitedValidatorsByStakingModule=reported_validators_values)
+    oracle_report(
+        cl_diff=ETH(300),
+        stakingModuleIdsWithNewlyExitedValidators=list(reported_validators.keys()),
+        numExitedValidatorsByStakingModule=reported_validators_values,
+    )
 
     count = oracle_report_sanity_checker.getReportDataCount()
     assert count > 0
     (_, stored_exited_validators, _) = oracle_report_sanity_checker.reportData(count - 1)
 
     assert stored_exited_validators == sum(reported_validators_values)
+
 
 def test_negative_rebase_correct_exited_validators_count_neg_rebase(oracle_report_sanity_checker):
     locator = contracts.lido_locator
@@ -44,14 +49,18 @@ def test_negative_rebase_correct_exited_validators_count_neg_rebase(oracle_repor
     reported_validators = exited_validators_count()
 
     reported_validators_values = [value + 3 for value in reported_validators.values()]
-    oracle_report(cl_diff=-ETH(40000), stakingModuleIdsWithNewlyExitedValidators=list(reported_validators.keys()),
-                   numExitedValidatorsByStakingModule=reported_validators_values)
+    oracle_report(
+        cl_diff=-ETH(40000),
+        stakingModuleIdsWithNewlyExitedValidators=list(reported_validators.keys()),
+        numExitedValidatorsByStakingModule=reported_validators_values,
+    )
 
     count = oracle_report_sanity_checker.getReportDataCount()
     assert count > 0
     (_, stored_exited_validators, _) = oracle_report_sanity_checker.reportData(count - 1)
 
     assert stored_exited_validators == sum(reported_validators_values)
+
 
 def test_negative_rebase_correct_balance_neg_rebase(oracle_report_sanity_checker):
     locator = contracts.lido_locator
@@ -78,12 +87,32 @@ def test_blocked_huge_negative_rebase(oracle_report_sanity_checker):
     locator = contracts.lido_locator
     assert oracle_report_sanity_checker.address == locator.oracleReportSanityChecker()
 
-    (_, cl_validators, cl_balance) = contracts.lido.getBeaconStat()
+    # Advance the chain 60 days more without accounting oracle reports
+    # The idea is to simplify the calculation of the exited validators for 18 and 54 days ago
+    chain.sleep(60 * 24 * 60 * 60)
+    chain.mine(1)
 
-    max_cl_balance = (INITIAL_SLASHING_AMOUNT_PWEI + INACTIVITY_PENALTIES_AMOUNT_PWEI) * ONE_PWEI * cl_validators
-    error_cl_decrease = cl_balance // 10    # 10% of current balance will lead to error
+    (_, cl_validators, cl_balance) = contracts.lido.getBeaconStat()
+    count = oracle_report_sanity_checker.getReportDataCount()
+    assert count > 0
+    (_, stored_exited_validators, _) = oracle_report_sanity_checker.reportData(count - 1)
+
+    max_cl_balance = (
+        (INITIAL_SLASHING_AMOUNT_PWEI + INACTIVITY_PENALTIES_AMOUNT_PWEI)
+        * ONE_PWEI
+        * (cl_validators - stored_exited_validators)
+    )
+    error_cl_decrease = cl_balance // 10  # 10% of current balance will lead to error
+
+    print(encode_error("IncorrectCLBalanceDecrease(uint256, uint256)", [error_cl_decrease, max_cl_balance]))
     with reverts(encode_error("IncorrectCLBalanceDecrease(uint256, uint256)", [error_cl_decrease, max_cl_balance])):
-        oracle_report(cl_diff=-error_cl_decrease, exclude_vaults_balances=True, silent=True)
+        oracle_report(
+            cl_diff=-error_cl_decrease,
+            exclude_vaults_balances=True,
+            simulation_block_identifier=chain.height,
+            silent=True,
+        )
+
 
 def test_negative_rebase_more_than_54_reports(oracle_report_sanity_checker):
     locator = contracts.lido_locator
@@ -92,8 +121,11 @@ def test_negative_rebase_more_than_54_reports(oracle_report_sanity_checker):
     reported_validators_values = exited_validators_count().values()
     for _ in range(58):
         reported_validators_values = [value + 3 for value in reported_validators_values]
-        oracle_report(cl_diff=-ETH(400), stakingModuleIdsWithNewlyExitedValidators=exited_validators_count().keys(),
-                       numExitedValidatorsByStakingModule=reported_validators_values)
+        oracle_report(
+            cl_diff=-ETH(400),
+            stakingModuleIdsWithNewlyExitedValidators=exited_validators_count().keys(),
+            numExitedValidatorsByStakingModule=reported_validators_values,
+        )
 
     count = oracle_report_sanity_checker.getReportDataCount()
     assert count > 0

--- a/tests/regression/test_staking_limits.py
+++ b/tests/regression/test_staking_limits.py
@@ -1,12 +1,14 @@
 """
 Tests for lido staking limits
 """
+
 import pytest
 import eth_abi
 
 from brownie import web3, convert, reverts, ZERO_ADDRESS, chain
 from utils.config import contracts
 from utils.test.helpers import ONE_ETH
+from utils.balance import set_balance
 
 
 @pytest.fixture(scope="module")
@@ -88,6 +90,8 @@ def test_staking_limit_initial_not_zero():
     [(10**6, 10**4), (10**12, 10**10), (10**18, 10**16)],
 )
 def test_staking_limit_updates_per_block_correctly(voting, stranger, limit_max, limit_per_block):
+    set_balance(stranger.address, 1000000)
+
     # Should update staking limits after submit
     contracts.lido.setStakingLimit(limit_max, limit_per_block, {"from": voting})
     staking_limit_before = contracts.lido.getCurrentStakeLimit()

--- a/utils/balance.py
+++ b/utils/balance.py
@@ -1,6 +1,7 @@
 from brownie import accounts, web3
 from utils.test.helpers import ETH
 
+
 def set_balance_in_wei(address, balance):
     account = accounts.at(address, force=True)
     providers = ["evm_setAccountBalance", "hardhat_setBalance", "anvil_setBalance"]
@@ -15,8 +16,9 @@ def set_balance_in_wei(address, balance):
             if e.args[0].get("message") != f"Method {provider} is not supported":
                 raise e
 
-    assert account.balance() == balance, f"Failed to set balance for account: {address}"
+    assert account.balance() == balance, f"Failed to set balance {balance} for account: {address}"
     return account
+
 
 def set_balance(address, balanceInEth):
     balance = ETH(balanceInEth)


### PR DESCRIPTION
Fix tests:
- [x] balance_check_middleware rollback balance changes
- [x] make stake limit tests not requiring the middleware to execute
- [x] fix negative rebase test to be future-proof against the post-vote state
- [x] port Oracle report simulation changing the `lastProcessingRefSlot` as done in the real off-chain `lido-oracle` code
- [x] `black` formatting against the changed files 