### PR TITLE
fix: module loading in `retrieve_vote_script`

### DIFF
--- a/scripts/ci/prepare_environment.py
+++ b/scripts/ci/prepare_environment.py
@@ -1,4 +1,5 @@
 import os
+import importlib
 
 from typing import Callable, Tuple, List
 
@@ -91,8 +92,8 @@ def retrieve_vote_script() -> Tuple[Callable, Callable] | None:
     module_name = f"scripts.{script_name}"
 
     try:
-        exec(f"from {module_name} import start_vote, get_vote_items")
-        return locals()['start_vote'], locals()['get_vote_items']
+        module = importlib.import_module(module_name)
+        return module.start_vote, module.get_vote_items
     except ImportError:
         raise AttributeError(
             f"'start_vote' and/or 'get_vote_items' not found in {script_path}."


### PR DESCRIPTION
removed the use of `exec` and `locals()` inside `retrieve_vote_script`.
this was unreliable, since `exec` doesn’t guarantee variables end up in `locals()` when called from within a function.

now the code uses `importlib.import_module` instead, which cleanly imports the module and provides direct access to `start_vote` and `get_vote_items`.
this makes the logic safer and more predictable.
