### PR TITLE
ci: pass brownie_fork_tests inputs via env before shell

### DIFF
--- a/.github/actions/brownie_fork_tests/action.yml
+++ b/.github/actions/brownie_fork_tests/action.yml
@@ -56,6 +56,8 @@ runs:
 
     - name: Show system info
       shell: bash
+      env:
+        VOTE_TYPE: ${{ inputs.vote }}
       run: |
         echo "Memory and swap:"
         free -h
@@ -67,12 +69,13 @@ runs:
         echo "CPU units"
         nproc --all
         echo "Vote type"
-        echo ${{ inputs.vote }}
+        echo "$VOTE_TYPE"
 
     - name: Run tests
       shell: bash
-      run: >
-        ${{ inputs.command }}
       env:
         ETHERSCAN_TOKEN: ${{ inputs.etherscan }}
         ETH_RPC_URL: ${{ inputs.rpc_url }}
+        COMMAND: ${{ inputs.command }}
+      run: |
+        bash -lc "$COMMAND"


### PR DESCRIPTION
## Summary
The `brownie_fork_tests` composite action interpolated `inputs.vote` and `inputs.command` directly into `run:` scripts. Move them into `env:` and expand shell variables instead (`"$VOTE_TYPE"`, `bash -lc "$COMMAND"`).

## Test plan
- [ ] Fork-test workflow still prints vote type
- [ ] Configured `command` still runs under the same etherscan/rpc env


Made with [Cursor](https://cursor.com)